### PR TITLE
feat : MOA-161- Unify Button Component style with figma design

### DIFF
--- a/src/app/[year]/(components)/common/Button.tsx
+++ b/src/app/[year]/(components)/common/Button.tsx
@@ -5,40 +5,53 @@ import { css } from "@emotion/react";
 export interface ButtonProps {
   label?: string;
   className?: string;
-  size?: "small" | "medium" | "long" | "circle";
-  color?: "black" | "red";
+  size?: "small" | "medium" | "long" | "circle" | "modalBtn";
+  color?: "black" | "white" | "red" | "blocked" | "none";
   onClick?: () => void; // toast alert 의 onCLick 속성 추가
 }
 
 //간단하게만 적었습니당
 export const buttonSize = {
   small: css`
-    width: 50px;
-    height: 30px;
+    max-width: 128px;
+    width: 100%;
+    height: 56px;
   `,
   medium: css`
     max-width: 316px;
     width: 100%;
     height: 63px;
-    padding: 14px 32px;
-    font-size: 16px;
-    font-weight: 500;
-    border-radius: 60px;
-    transition: 0.2s ease;
   `,
   long: css`
-    max-width: 200px;
+    max-width: 370px;
     width: 100%;
-    height: 30px;
+    height: 63px;
+  `,
+  circle: css`
+    border-radius: 100%;
+    width: 60px;
+    height: 60px;
+  `,
+  modalBtn: css`
+    max-width: 174px;
+    width: 100%;
+    height: 56px;
   `,
 };
 
 export const buttonColor = {
   black: css`
-    background-color: black;
+    background-color: var(--color-black);
     color: white;
     &:hover {
-      background-color: rgb(150, 149, 149);
+      background-color: var(--color-gray-800);
+    }
+  `,
+  white: css`
+    background-color: white;
+    color: white;
+    &:hover {
+      transform: scale(1.03);
     }
   `,
   red: css`
@@ -47,6 +60,20 @@ export const buttonColor = {
     &:hover {
       background-color: rgb(255, 123, 123);
     }
+  `,
+  //버튼 상호작용 x일 때
+  blocked: css`
+    background-color: var(--color-gray-300);
+    color: var(--color-gray-500);
+    font-weight: bold;
+    cursor: default;
+  `,
+  //배경 X, modal용
+  none: css`
+    background-color: transparent;
+    color: var(--color-gray-300);
+    font-weight: bold;
+    box-shadow: none;
   `,
 };
 
@@ -57,7 +84,10 @@ const ButtonStyle = styled.button<ButtonProps>`
   border: none;
   margin: 10px;
   overflow: hidden;
-
+  border-radius: 60px;
+  font-size: 16px;
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3);
+  transition: 0.3s ease;
   ${props => buttonSize[props.size]};
   ${props => buttonColor[props.color]};
 `;


### PR DESCRIPTION
## 📌제목 : 제목추가

### ➡️PR 방향

- [ ] 초기(첫 푸시) → 첫 푸시 내용 설명 요망
- [x] 수정 → 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 버그 → 버그 스크린 샷 첨부 요망
- [ ] 요청 → 요청 부분 설명 요망

### 📝내용

- 공통 버튼 컴포넌트 CSS 스타일을 피그마상과 통일 시켰습니다
- blocked 됐을 때 스타일(상호작용 불가), 모달용 스타일, 아이콘 전용(둥근 버튼) 등이 추가 됐습니다

---

#### ⛓️연결된 이슈 :

closes MOA-161
