### PR TITLE
Feat : Add delete logic for select-moa/moaBox(letter) ➕ Add logic and refactor notification page

### DIFF
--- a/src/app/[year]/(components)/common/Alert.tsx
+++ b/src/app/[year]/(components)/common/Alert.tsx
@@ -2,6 +2,7 @@
 
 import React, { ReactNode } from "react";
 import Swal from "sweetalert2";
+import "@/styles/Alert.css";
 
 // 👉 사용예제
 // <AlertProvider> {({ showAlert, showConfirmModal }) => ( 이곳에 아래 버튼을 넣어주세요 )} </AlertProvider>
@@ -70,7 +71,7 @@ export const AlertProvider = ({ children }: AlertRenderProps): JSX.Element => {
       cancelButtonColor: "#1b1b1b",
       confirmButtonText: "예",
       cancelButtonText: "아니오",
-    }).then((result) => {
+    }).then(result => {
       if (result.isConfirmed) {
         Swal.fire({
           title: "완료되었습니다!",

--- a/src/app/[year]/(components)/common/Modal.tsx
+++ b/src/app/[year]/(components)/common/Modal.tsx
@@ -36,7 +36,7 @@ const defaultModalStyle: CSSProperties = {
 };
 // 오버레이(배경) 스타일
 export const defaultOverlayStyle: CSSProperties = {
-  backgroundColor: "rgba(0, 0, 0, 0.7)",
+  backgroundColor: "rgba(0, 0, 0, 0.8)",
   position: "absolute",
   top: 0,
   right: 0,

--- a/src/app/[year]/(components)/common/Sidebar.tsx
+++ b/src/app/[year]/(components)/common/Sidebar.tsx
@@ -30,13 +30,13 @@ export default function Sidebar() {
 
   // 사이드바 메뉴들
   const sidebarItems: SidebarItem[] = [
-    { id: "1", label: "마이페이지", href: "/2025/mypage", icon: my_page },
     {
-      id: "2",
+      id: "1",
       label: "모아 선택 화면",
       href: "/2025/moa/select-moa",
       icon: select_moa,
     },
+    { id: "2", label: "마이페이지", href: "/2025/mypage", icon: my_page },
     {
       id: "3",
       label: "지난모아 보관함",

--- a/src/app/[year]/(components)/loading.tsx
+++ b/src/app/[year]/(components)/loading.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React from "react";
+import Image from "next/image";
+import moaCat from "@/../../public/assets/icons/cat.svg";
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  height: "100vh",
+  //   backgroundColor: "var(--color-gray-500)", // 필요에 따라 배경색 조정
+};
+
+const spinnerStyle: React.CSSProperties = {
+  width: "100px",
+  height: "100px",
+  animation: "spin 3s linear infinite",
+};
+
+export default function Loading() {
+  return (
+    <div style={containerStyle}>
+      <style>
+        {`
+          @keyframes spin {
+            to { transform: rotate(360deg); }
+          }
+        `}
+      </style>
+      <Image src={moaCat} alt="moa cat image" style={spinnerStyle} />
+    </div>
+  );
+}

--- a/src/app/[year]/friendlist/(components)/FriendInfo.tsx
+++ b/src/app/[year]/friendlist/(components)/FriendInfo.tsx
@@ -4,7 +4,7 @@ import styles from "@/styles/friendlist.module.css";
 interface FriendInfo {
   id: string;
   nickname: string;
-  profileImage: string;
+  profileImage?: string;
   moaBoxOngoing: boolean;
 }
 
@@ -15,7 +15,9 @@ export default function FriendInfo(props: FriendInfo) {
       <Link href={`/2025/moa/select-moa/${id}`} className={styles.friendItem}>
         <div
           className={styles.profileImage}
-          style={{ backgroundImage: `url(${profileImage})` }}
+          style={
+            profileImage ? { backgroundImage: `url(${profileImage})` } : {}
+          }
         />
         <div>
           <div className={styles.infoWrapper}>

--- a/src/app/[year]/friendlist/(components)/FriendListContent.tsx
+++ b/src/app/[year]/friendlist/(components)/FriendListContent.tsx
@@ -11,7 +11,7 @@ interface Friend {
   id: string;
   name: string;
   nickname: string;
-  profileImage: string;
+  profileImage?: string;
   moaBoxOngoing: boolean;
 }
 

--- a/src/app/[year]/friendlist/(components)/FriendListContent.tsx
+++ b/src/app/[year]/friendlist/(components)/FriendListContent.tsx
@@ -5,7 +5,7 @@ import Modal from "../../(components)/common/Modal";
 import FriendInfo from "./FriendInfo";
 import friendListIcon from "@/../public/assets/icons/nav_sidebar/friend_list_icon.svg";
 import NoFriendImg from "@/../public/assets/broke_cat.svg";
-import styles from "@/styles/friendlist.module.css";
+import styles from "@/styles/notification.module.css";
 
 interface Friend {
   id: string;

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import React, { PropsWithChildren, ReactElement } from "react";
 import { AlertProvider } from "@/app/[year]/(components)/common/Alert";
 
@@ -22,15 +21,6 @@ export default function HandleDeleteLetter({ children, letterId }: Props) {
                 const res = await fetch(`/api/letter/${letterId}`, {
                   method: "DELETE",
                 });
-                // if (res.ok) {
-                //   showAlert("편지가 삭제되었습니다.", "성공");
-                //   location.reload();
-                // } else {
-                //   showAlert(
-                //     "편지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
-                //     "오류"
-                //   );
-                // }
               } catch (error) {
                 console.error("편지 삭제 중 문제 발생", error);
                 showAlert("삭제 중 오류가 발생했습니다.", "오류");

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -1,56 +1,52 @@
+"use client";
+
 import React, { PropsWithChildren, ReactElement } from "react";
-import Swal from "sweetalert2";
+import { AlertProvider } from "@/app/[year]/(components)/common/Alert";
 
 interface Props extends PropsWithChildren {
   children: ReactElement;
   letterId: number;
 }
 
-export default function HandleDeleteLetter(props: Props) {
-  const { children, letterId } = props;
-  const clickHandler = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    const result = await Swal.fire({
-      text: "편지를 삭제하시겠습니까?",
-      icon: "question",
-      showCancelButton: true,
-      confirmButtonColor: "#ff8473",
-      cancelButtonColor: "#aeaeae",
-      confirmButtonText: "확인",
-      cancelButtonText: "취소",
-      customClass: {
-        popup: "swal-popup",
-      },
-    });
-    if (result.isDismissed) return;
-    if (result.isConfirmed) {
-      //편지 삭제 요청
-      try {
-        const res = await fetch(`/api/letter/${letterId}`, {
-          method: "DELETE",
-        });
-        if (res.ok) {
-          await Swal.fire({
-            icon: "success",
-            text: "편지가 삭제되었습니다.",
+export default function HandleDeleteLetter({ children, letterId }: Props) {
+  return (
+    <AlertProvider>
+      {({ showAlert, showConfirmModal }) => {
+        const clickHandler = async (e: React.MouseEvent) => {
+          e.stopPropagation();
+          showConfirmModal({
+            message: "삭제한 편지는 복구할 수 없습니다.",
+            confirmMessage: "편지를 삭제하시겠습니까?",
+            onConfirm: async () => {
+              try {
+                const res = await fetch(`/api/letter/${letterId}`, {
+                  method: "DELETE",
+                });
+                // if (res.ok) {
+                //   showAlert("편지가 삭제되었습니다.", "성공");
+                //   location.reload();
+                // } else {
+                //   showAlert(
+                //     "편지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+                //     "오류"
+                //   );
+                // }
+              } catch (error) {
+                console.error("편지 삭제 중 문제 발생", error);
+                showAlert("삭제 중 오류가 발생했습니다.", "오류");
+              }
+            },
+            onCancel: () => {
+              showAlert("삭제가 취소되었습니다.", "정보");
+            },
           });
-          location.reload();
-        } else {
-          await Swal.fire({
-            icon: "error",
-            text: "편지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
-          });
-        }
-      } catch (error) {
-        console.error("편지 삭제 중 문제 발생", error);
-        Swal.fire({ icon: "error", text: "삭제 중 오류가 발생했습니다." });
-      }
-    }
-  };
-  //자식 컴포넌트에 onClick 핸들러 부착
-  const childWithHandler = React.cloneElement(children, {
-    onClick: clickHandler,
-  });
+        };
 
-  return childWithHandler;
+        const childWithHandler = React.cloneElement(children, {
+          onClick: clickHandler,
+        });
+        return childWithHandler;
+      }}
+    </AlertProvider>
+  );
 }

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren, ReactElement } from "react";
+import Swal from "sweetalert2";
+
+interface Props extends PropsWithChildren {
+  children: ReactElement;
+  letterId: number;
+}
+
+export default function HandleDeleteLetter(props: Props) {
+  const { children, letterId } = props;
+  const clickHandler = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const result = await Swal.fire({
+      text: "편지를 삭제하시겠습니까?",
+      icon: "question",
+      showCancelButton: true,
+      confirmButtonColor: "#ff8473",
+      cancelButtonColor: "#aeaeae",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+      customClass: {
+        popup: "swal-popup",
+      },
+    });
+    if (result.isDismissed) return;
+    if (result.isConfirmed) {
+      //편지 삭제 요청
+      try {
+        const res = await fetch(`/api/letter/${letterId}`, {
+          method: "DELETE",
+        });
+        if (res.ok) {
+          await Swal.fire({
+            icon: "success",
+            text: "편지가 삭제되었습니다.",
+          });
+          location.reload();
+        } else {
+          await Swal.fire({
+            icon: "error",
+            text: "편지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+          });
+        }
+      } catch (error) {
+        console.error("편지 삭제 중 문제 발생", error);
+        Swal.fire({ icon: "error", text: "삭제 중 오류가 발생했습니다." });
+      }
+    }
+  };
+  //자식 컴포넌트에 onClick 핸들러 부착
+  const childWithHandler = React.cloneElement(children, {
+    onClick: clickHandler,
+  });
+
+  return childWithHandler;
+}

--- a/src/app/[year]/moa/mymoa/(components)/(features)/OpenLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/OpenLetter.tsx
@@ -36,7 +36,7 @@ export default function OpenLetter({ children, letter }: Props) {
       const combinedLetter: Letter = { ...letter, ...letterDetail };
       openLetterModal(combinedLetter);
     } catch (error) {
-      if (error.status === 401) {
+      if (error.status === 403 || error.status === 401) {
         Swal.fire({
           toast: true,
           text: "🧸 이 편지는 주인만 볼 수 있어요!",

--- a/src/app/[year]/moa/mymoa/(components)/(features)/OpenLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/OpenLetter.tsx
@@ -4,6 +4,7 @@ import { LetterBase, Letter } from "@/types/moabox";
 import { PropsWithChildren, useCallback } from "react";
 import { useLetterModalContext } from "@/contexts/LetterModalContext";
 import useLetterCache from "@/hooks/useLetterCache";
+import Swal from "sweetalert2";
 
 interface Props extends PropsWithChildren {
   letter: LetterBase;
@@ -35,6 +36,16 @@ export default function OpenLetter({ children, letter }: Props) {
       const combinedLetter: Letter = { ...letter, ...letterDetail };
       openLetterModal(combinedLetter);
     } catch (error) {
+      if (error.status === 401) {
+        Swal.fire({
+          toast: true,
+          text: "🧸 이 편지는 주인만 볼 수 있어요!",
+          position: "bottom",
+          showConfirmButton: false,
+          timer: 2000,
+        });
+        return;
+      }
       console.error("편지 여는 중 문제 발생", error);
     }
   }, [letter, fetchLetterData, openLetterModal]);

--- a/src/app/[year]/moa/mymoa/(components)/(ui)/LetterGrid.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(ui)/LetterGrid.tsx
@@ -10,7 +10,6 @@ interface LetterGridProps {
 export default function LetterGrid({ letters }: LetterGridProps) {
   const firstRow = letters.slice(0, 2);
   const restRow = letters.slice(2);
-  console.log(letters);
   return (
     <div style={{ display: "flex", justifyContent: "center" }}>
       <div className={styles.mailBoxGrid}>

--- a/src/app/[year]/moa/mymoa/(components)/(ui)/LetterModal.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(ui)/LetterModal.tsx
@@ -10,6 +10,7 @@ import Button from "@/app/[year]/(components)/common/Button";
 import deleteBtn from "@/../../public/assets/icons/trash_can_icon.svg";
 import downloadBtn from "@/../../public/assets/icons/download_icon.svg";
 import styles from "@/styles/LetterModal.module.css";
+import HandleDeleteLetter from "../(features)/HandleDeleteLetter";
 
 interface LetterModalProps {
   isOpen: boolean;
@@ -50,15 +51,16 @@ export default function LetterModal(props: LetterModalProps) {
             </div>
             {/* 편지 삭제 버튼 */}
             <div className={styles.deleteButtonContainer}>
-              {/* 편지 삭제 비즈니스 로직 추가 예정 */}
-              <button className={styles.deleteButton} onClick={onClose}>
-                <Image
-                  src={deleteBtn}
-                  alt="delete letter button"
-                  width={24}
-                  height={24}
-                />
-              </button>
+              <HandleDeleteLetter letterId={letter.id}>
+                <button className={styles.deleteButton}>
+                  <Image
+                    src={deleteBtn}
+                    alt="delete letter button"
+                    width={24}
+                    height={24}
+                  />
+                </button>
+              </HandleDeleteLetter>
             </div>
           </div>
         </div>

--- a/src/app/[year]/moa/mymoa/[id]/page.tsx
+++ b/src/app/[year]/moa/mymoa/[id]/page.tsx
@@ -53,7 +53,6 @@ export default async function MyMoaBoxPage({ params }) {
     // 현재 로그인한 사용자가 소유자인지 확인
     isOwner = moaBox.ownerId === currentUser.id;
   }
-  console.log(session);
   //디자인 정보 불러오기
   const backgroundDesign = moaBox.backgroundDesign?.imageURL;
   const mailBoxDesign = moaBox.mailBoxDesign?.imageURL;

--- a/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
+++ b/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
@@ -12,6 +12,7 @@ import deleteBtn from "../../../../../../public/assets/icons/trash_can_icon.svg"
 import Button from "@/app/[year]/(components)/common/Button";
 import styles from "../../../../../styles/selectMoa.module.css";
 import { MoaBox } from "@/types/moabox"; //props 타입
+import Swal from "sweetalert2";
 
 export interface SelectCarouselProps {
   friendId?: string;
@@ -25,7 +26,6 @@ export default function SelectCarousel({
   const router = useRouter();
   const [nowSelected, setNowSelected] = useState<number | null>(null);
   const containerRef = useRef(null); // 컨테이너를 참조하기 위한 ref
-
   // 선택된 moaBox 페이지로 이동 함수
   const handleRoute = () => {
     if (nowSelected != null && friendId) {
@@ -34,10 +34,36 @@ export default function SelectCarousel({
       router.push(`/2025/moa/mymoa/${nowSelected}`);
     }
   };
+  //선택한 moaBox 삭제하는 함수
+  const handleMoaBoxDelete = async (moaBoxId: number) => {
+    const result = await Swal.fire({
+      icon: "question",
+      text: "삭제하시겠습니까? 삭제한 항목은 복구할 수 없습니다.",
+      showCancelButton: true,
+      confirmButtonColor: "#ff8473",
+      cancelButtonColor: "#aeaeae",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    });
+    if (!result.isConfirmed) return;
 
-  //특정 moaBox 삭제하는 함수(id : moaBox id)
-  const handleMoaBoxDelete = (id: number) => {
-    console.log(id);
+    if (result.isConfirmed) {
+      try {
+        const response = await fetch(`/api/moa/${moaBoxId}`, {
+          method: "DELETE",
+        });
+        const data = await response.json();
+        if (data.success) {
+          Swal.fire({ icon: "success", text: "성공적으로 삭제되었습니다!" });
+          router.refresh();
+        } else {
+          Swal.fire({ icon: "error", text: data.error });
+        }
+      } catch (error) {
+        console.error("모아 박스 삭제 중 문제 발생!", error);
+        Swal.fire({ icon: "error", text: "삭제 중 오류가 발생했습니다." });
+      }
+    }
   };
 
   // 클릭 이벤트 리스너 추가 (컴포넌트 외부 클릭 시 선택 해제)
@@ -89,7 +115,10 @@ export default function SelectCarousel({
               onClick={() => {
                 setNowSelected(moaBox.id);
               }}
-              className={`${styles.card} ${styles.moaCard} ${
+              style={{
+                backgroundImage: `url(${moaBox.backgroundDesign.imageURL})`,
+              }}
+              className={`${styles.card} ${
                 nowSelected === moaBox.id ? styles.selected : ""
               }`}
             >
@@ -105,11 +134,13 @@ export default function SelectCarousel({
               )}
               {/* 임시 데이터 표시: 나중에 모아박스 이미지로 교체 예정 */}
               <div className={styles.moaBoxContainer}>
-                {moaBox.ownerId}
-                <br />
-                moaBox Id:{moaBox.id}
-                <br />
-                title: {moaBox.title}
+                <div
+                  className={styles.moaBoxImage}
+                  style={{
+                    backgroundImage: `url(${moaBox.mailBoxDesign.imageURL})`,
+                  }}
+                />
+                <h4 className={styles.moaBoxName}>{moaBox.title}</h4>
               </div>
             </SwiperSlide>
           ))}

--- a/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
+++ b/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
@@ -55,7 +55,7 @@ export default function SelectCarousel({
           Swal.fire({ icon: "success", text: "성공적으로 삭제되었습니다!" });
           router.refresh();
         } else {
-          Swal.fire({ icon: "error", text: data.error });
+          Swal.fire({ icon: "error", text: "삭제 중 오류가 발생했습니다." });
         }
       } catch (error) {
         console.error("모아 박스 삭제 중 문제 발생!", error);

--- a/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
+++ b/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
@@ -28,9 +28,7 @@ export default function SelectCarousel({
   const containerRef = useRef(null); // 컨테이너를 참조하기 위한 ref
   // 선택된 moaBox 페이지로 이동 함수
   const handleRoute = () => {
-    if (nowSelected != null && friendId) {
-      router.push(`/2025/moa/friendmoa/${nowSelected}`);
-    } else if (nowSelected != null && !friendId) {
+    if (nowSelected != null && nowSelected !== undefined) {
       router.push(`/2025/moa/mymoa/${nowSelected}`);
     }
   };

--- a/src/app/[year]/moa/select-moa/[friendId]/page.tsx
+++ b/src/app/[year]/moa/select-moa/[friendId]/page.tsx
@@ -17,6 +17,10 @@ export default async function FriendSelectMoaPage({ params }) {
     where: {
       ownerId: friendId,
     },
+    include: {
+      backgroundDesign: true,
+      mailBoxDesign: true,
+    },
   });
 
   if (friendMoaBoxes.length === 0) {
@@ -33,11 +37,18 @@ export default async function FriendSelectMoaPage({ params }) {
         }}
       >
         <Image src={NoMoaImage} alt="no moa" width={180} />
-        <p>진행 중인 모아가 없습니다 ...</p>
+        <p>진행 중인 모아 박스스가 없습니다 ...</p>
       </div>
     );
   }
-
+  <SelectCarousel
+    friendId={friendId}
+    moaBoxes={friendMoaBoxes.map(box => ({
+      ...box,
+      backgroundDesign: box.backgroundDesign || null,
+      mailBoxDesign: box.mailBoxDesign || null,
+    }))}
+  />;
   return (
     <>
       {/* 모아 박스 캐러셀 컴포넌트 */}

--- a/src/app/[year]/moa/select-moa/layout.tsx
+++ b/src/app/[year]/moa/select-moa/layout.tsx
@@ -8,7 +8,7 @@ export default function Layout({ children }) {
       <div className={styles.layoutContainer}>
         <div className={styles.header}>
           <Image src={icon} alt="select_moa_icon" />
-          <h3 className={styles.title}>모아 선택 화면</h3>
+          <h3 className={styles.title}>모아 박스 선택 화면</h3>
         </div>
 
         <p className={styles.description}>

--- a/src/app/[year]/moa/select-moa/page.tsx
+++ b/src/app/[year]/moa/select-moa/page.tsx
@@ -16,6 +16,10 @@ export default async function SelectMoaPage() {
     where: {
       ownerId: session.user.id,
     },
+    include: {
+      backgroundDesign: { select: { imageURL: true } },
+      mailBoxDesign: { select: { imageURL: true } },
+    },
   });
 
   return (

--- a/src/app/[year]/notification/(components)/NotificationContent.tsx
+++ b/src/app/[year]/notification/(components)/NotificationContent.tsx
@@ -6,21 +6,16 @@ import Image from "next/image";
 import moa_cat from "../../../../../public/assets/icons/notification/notification_moa_cat.svg";
 import accept_btn from "../../../../../public/assets/icons/notification/notification_yes_btn.svg";
 import reject_btn from "../../../../../public/assets/icons/notification/notification_no_btn.svg";
-import styles from "../../../../styles/notification.module.css";
+import styles from "@/styles/notification.module.css";
 import defaultImg from "@/../../public/assets/default_img.png";
-import { BaseNotification, MyNotification } from "@/types/notification";
+import {
+  BaseNotification,
+  MyNotification,
+  Notifications,
+} from "@/types/notification";
 import Swal from "sweetalert2"; //임시시
 
-interface NotificationContentProps {
-  notifications: {
-    myNotifications: MyNotification[];
-    moaNotifications: BaseNotification[];
-  };
-}
-
-export default function NotificationContent({
-  notifications,
-}: NotificationContentProps) {
+export default function NotificationContent({ notifications }: Notifications) {
   const router = useRouter();
   //알림 종류에 따라 분류
   //내 소식
@@ -121,6 +116,8 @@ export default function NotificationContent({
 
         if (data.success) {
           Swal.fire({ icon: "info", text: "친구 요청이 거절되었습니다" });
+          router.refresh();
+          return;
         } else {
           Swal.fire({
             icon: "warning",
@@ -201,7 +198,7 @@ export default function NotificationContent({
                 {/* 모아 소식 알림 이미지 */}
                 <Image src={moa_cat} alt="moa-cat" />
                 {/* 알림 메시지 */}
-                <p className={styles.message}>{notification.message}</p>
+                {<p className={styles.message}>{notification.message}</p>}
               </div>
             ))
           )}

--- a/src/app/[year]/notification/(components)/NotificationContent.tsx
+++ b/src/app/[year]/notification/(components)/NotificationContent.tsx
@@ -1,3 +1,6 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import moa_cat from "../../../../../public/assets/icons/notification/notification_moa_cat.svg";
@@ -6,9 +9,7 @@ import reject_btn from "../../../../../public/assets/icons/notification/notifica
 import styles from "../../../../styles/notification.module.css";
 import defaultImg from "@/../../public/assets/default_img.png";
 import { BaseNotification, MyNotification } from "@/types/notification";
-
-//FROM_MOA/LETTER_RECEIVED 알림 읽음 처리 로직
-// useEffect(() => {}, []);
+import Swal from "sweetalert2"; //임시시
 
 interface NotificationContentProps {
   notifications: {
@@ -20,11 +21,121 @@ interface NotificationContentProps {
 export default function NotificationContent({
   notifications,
 }: NotificationContentProps) {
+  const router = useRouter();
   //알림 종류에 따라 분류
   //내 소식
   const myNotifications: MyNotification[] = notifications.myNotifications;
   //모아 소식
   const moaNotifications: BaseNotification[] = notifications.moaNotifications;
+
+  // 모아 소식 읽음 처리
+  useEffect(() => {
+    async function patchMoaNotificationAsRead() {
+      try {
+        //읽음처리 되지 않은 모아 소식이 있는지
+        const unread = moaNotifications.filter(
+          notification => !notification.read
+        );
+        //있다면 read값 patch요청
+        if (unread.length > 0) {
+          await fetch("/api/notification", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              ids: unread.map(notification => notification.id),
+              read: true,
+            }),
+          });
+        }
+      } catch (error) {
+        console.error("모아 소식 읽음 처리 중 문제 발생", error);
+      }
+    }
+    patchMoaNotificationAsRead();
+  }, [moaNotifications]);
+
+  // 내 소식: 친구 요청 수락
+  const handleAccept = async (e: React.MouseEvent, notificationId: number) => {
+    e.preventDefault();
+    const result = await Swal.fire({
+      icon: "question",
+      text: "친구 요청을 수락하시겠습니까?",
+      showCancelButton: true,
+      confirmButtonColor: "#ff8473",
+      cancelButtonColor: "#aeaeae",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    });
+
+    if (!result.isConfirmed) return;
+    if (result.isConfirmed) {
+      try {
+        const res = await fetch("/api/notification/friend-request", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ notificationId }),
+        });
+        const data = await res.json();
+        if (data.success) {
+          await Swal.fire({
+            icon: "success",
+            text: "친구 요청이 수락되었습니다",
+          });
+        } else {
+          Swal.fire({
+            icon: "error",
+            text: "수락 중 문제가 발생했습니다",
+          });
+        }
+      } catch (error) {
+        console.error("친구 요청 수락 중 문제 발생", error);
+        Swal.fire({
+          icon: "error",
+          text: "수락 중 문제가 발생했습니다.",
+        });
+      }
+    }
+  };
+
+  // 내 소식 : 친구 요청 거절
+  const handleReject = async (e: React.MouseEvent, notificationId: number) => {
+    e.preventDefault();
+    const result = await Swal.fire({
+      icon: "warning",
+      text: "친구 요청을 거절하시겠습니까? 해당 작업은 되돌릴 수 없습니다.",
+      showCancelButton: true,
+      confirmButtonColor: "#ff8473",
+      cancelButtonColor: "#aeaeae",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    });
+    if (!result.isConfirmed) return;
+    if (result.isConfirmed) {
+      try {
+        const res = await fetch(`/api/notification/friend-request`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ notificationId }),
+        });
+        const data = await res.json();
+
+        if (data.success) {
+          Swal.fire({ icon: "info", text: "친구 요청이 거절되었습니다" });
+        } else {
+          Swal.fire({
+            icon: "warning",
+            text: "요청 거절 중 문제가 발생했습니다",
+          });
+        }
+      } catch (error) {
+        console.error("친구 요청 거절 중 문제 발생", error);
+        Swal.fire({
+          icon: "warning",
+          text: "요청 거절 중 문제가 발생했습니다",
+        });
+      }
+    }
+  };
 
   return (
     <div className={styles.content_wrapper}>
@@ -55,10 +166,16 @@ export default function NotificationContent({
                 </p>
                 {/* 수락/거절 버튼 */}
                 <div className={styles.btn_wrapper}>
-                  <button className={styles.accept_btn}>
+                  <button
+                    className={styles.accept_btn}
+                    onClick={e => handleAccept(e, notification.id)}
+                  >
                     <Image src={accept_btn} alt="accept" />
                   </button>
-                  <button className={styles.reject_btn}>
+                  <button
+                    className={styles.reject_btn}
+                    onClick={e => handleReject(e, notification.id)}
+                  >
                     <Image src={reject_btn} alt="reject" />
                   </button>
                 </div>

--- a/src/app/[year]/notification/(components)/NotificationPageClient.tsx
+++ b/src/app/[year]/notification/(components)/NotificationPageClient.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Suspense } from "react";
+import Modal from "../../(components)/common/Modal";
+import NotificationContent from "./NotificationContent";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import Skeleton from "../../(components)/common/Skeleton";
+import { Notifications } from "@/types/notification";
+import Loading from "../../(components)/loading";
+
+export default function NotificationPageClient({
+  notifications,
+}: Notifications) {
+  const { status } = useSession();
+  const router = useRouter();
+
+  if (status === "loading") {
+    return <Loading />;
+  }
+
+  //Modal에 넘기는 함수
+  const onClose = () => {
+    router.back();
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={true}
+        title="알림함"
+        onClose={onClose}
+        showActionButtons={false}
+        content={
+          <Suspense fallback={<Skeleton width="100%" height="80px" />}>
+            <NotificationContent notifications={notifications} />
+          </Suspense>
+        }
+      />
+    </>
+  );
+}

--- a/src/app/[year]/notification/page.tsx
+++ b/src/app/[year]/notification/page.tsx
@@ -13,7 +13,6 @@ export default function NotificationPage() {
     moaNotifications: [],
   });
   const [loading, setLoading] = useState(true);
-  console.log(session);
   useEffect(() => {
     async function fetchNotifications() {
       if (session?.user?.id) {

--- a/src/app/[year]/notification/page.tsx
+++ b/src/app/[year]/notification/page.tsx
@@ -1,57 +1,31 @@
-"use client";
-import { Suspense, useEffect, useState } from "react";
-import Modal from "../(components)/common/Modal";
-import NotificationContent from "./(components)/NotificationContent";
-import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
+import React from "react";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/authoptions";
+import { headers } from "next/headers";
+import NotFound from "../(components)/not-found";
+import NotificationPageClient from "./(components)/NotificationPageClient";
 
-export default function NotificationPage() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
-  const [notifications, setNotifications] = useState({
-    myNotifications: [],
-    moaNotifications: [],
-  });
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    async function fetchNotifications() {
-      if (session?.user?.id) {
-        try {
-          const res = await fetch("/api/notification");
-          const data = await res.json();
-          setNotifications(data);
-        } catch (error) {
-          console.error("알림함 불러오는 중 문제 발생", error);
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        setLoading(false);
-      }
-    }
-    fetchNotifications();
-  }, [session]);
-
-  if (status === "loading" || loading) {
-    return <p>loading...</p>;
+export default async function NotificationPageServer() {
+  const baseURL = process.env.NEXT_PUBLIC_API_URL;
+  // 현재 요청의 헤더에서 쿠키 추출
+  const reqHeaders = await headers();
+  const cookie = reqHeaders.get("cookie") ?? "";
+  //세션 확인
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user) {
+    return redirect("/auth/login");
   }
+  const res = await fetch(`${baseURL}/api/notification`, {
+    cache: "no-store",
+    headers: { cookie },
+  });
+  //세션 없을 때
+  if (res.status === 401) return redirect("/auth/login");
+  //응답 값이 이상할 때
+  if (!res.ok) return NotFound();
 
-  //Modal에 넘기는 함수
-  const onClose = () => {
-    router.back();
-  };
+  const notifications = await res.json();
 
-  return (
-    <Modal
-      isOpen={true}
-      title="알림함"
-      onClose={onClose}
-      showActionButtons={false}
-      content={
-        <Suspense fallback="loading...">
-          <NotificationContent notifications={notifications} />
-        </Suspense>
-      }
-    />
-  );
+  return <NotificationPageClient notifications={notifications} />;
 }

--- a/src/app/api/friendlist/route.ts
+++ b/src/app/api/friendlist/route.ts
@@ -1,7 +1,7 @@
 import { getFriendship } from "@/lib/friendship";
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
-import authOptions from "../auth/authoptions"; // 상대 경로 수정
+import { authOptions } from "../auth/authoptions"; // 상대 경로 수정
 import { Session } from "next-auth"; // Session 타입 임포트
 
 export async function GET(request: Request) {
@@ -14,7 +14,6 @@ export async function GET(request: Request) {
       { status: 401 }
     );
   }
-
   try {
     const friends = await getFriendship(session.user.id);
     return NextResponse.json({ friends });

--- a/src/app/api/letter/[letterId]/route.ts
+++ b/src/app/api/letter/[letterId]/route.ts
@@ -169,5 +169,5 @@ export async function DELETE(
     console.error("모아 박스 삭제 중 문제 발생");
     return NextResponse.json({ error: error }, { status: 400 });
   }
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true }, { status: 200 });
 }

--- a/src/app/api/letter/[letterId]/route.ts
+++ b/src/app/api/letter/[letterId]/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/app/api/auth/authoptions";
 import prisma from "@/lib/prisma";
 import { Session } from "next-auth"; // Session 타입 임포트
+import { deleteLetter } from "@/lib/deletion";
+import { error } from "console";
 
 //편지 정보 받아오는용
 export async function GET(
@@ -140,4 +142,32 @@ export async function PATCH(
       { status: 500 }
     );
   }
+}
+
+//편지 삭제 로직
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ letterId: string }> }
+) {
+  const session = (await getServerSession(authOptions)) as Session | null;
+
+  if (!session || !session.user) {
+    return NextResponse.json({ connected: false }, { status: 401 });
+  }
+
+  const { letterId } = await params;
+  const letterIdNumber = Number(letterId);
+  if (!letterIdNumber) {
+    return NextResponse.json(
+      { error: "편지 아이디를 찾을 수 없습니다." },
+      { status: 400 }
+    );
+  }
+  //편지 삭제 요청
+  const result = await deleteLetter(letterIdNumber, session);
+  if (!result) {
+    console.error("모아 박스 삭제 중 문제 발생");
+    return NextResponse.json({ error: error }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
 }

--- a/src/app/api/moa/[moaBoxId]/route.ts
+++ b/src/app/api/moa/[moaBoxId]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/authoptions";
+import { Session } from "next-auth"; // Session 타입 임포트
+import { deleteMoaBox } from "@/lib/deletion";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { moaBoxId: string } }
+) {
+  // Session 타입 단언
+  const session = (await getServerSession(authOptions)) as Session | null;
+
+  if (!session || !session.user) {
+    return NextResponse.json({ connected: false }, { status: 401 });
+  }
+
+  //모아박스 아이디 받아오기
+  const moaBoxIdNum = Number(params.moaBoxId);
+  const result = await deleteMoaBox(moaBoxIdNum, session);
+  if (!result) {
+    console.error("모아 박스 삭제 중 문제 발생");
+    return NextResponse.json({ error: result.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/moa/[moaBoxId]/route.ts
+++ b/src/app/api/moa/[moaBoxId]/route.ts
@@ -6,8 +6,15 @@ import { deleteMoaBox } from "@/lib/deletion";
 
 export async function DELETE(
   request: Request,
-  { params }: { params: { moaBoxId: string } }
+  { params }: { params: Promise<{ moaBoxId: string }> }
 ) {
+  const { moaBoxId } = await params; // 비동기적으로 params 처리
+  if (!moaBoxId) {
+    return NextResponse.json(
+      { error: "조회할 아이디가 없습니다" },
+      { status: 400 }
+    );
+  }
   // Session 타입 단언
   const session = (await getServerSession(authOptions)) as Session | null;
 
@@ -16,7 +23,7 @@ export async function DELETE(
   }
 
   //모아박스 아이디 받아오기
-  const moaBoxIdNum = Number(params.moaBoxId);
+  const moaBoxIdNum = Number(moaBoxId);
   const result = await deleteMoaBox(moaBoxIdNum, session);
   if (!result) {
     console.error("모아 박스 삭제 중 문제 발생");

--- a/src/app/api/notification/friend-request/route.ts
+++ b/src/app/api/notification/friend-request/route.ts
@@ -39,7 +39,7 @@ export async function PATCH(request: Request) {
   // payload값에서 friendshipId와 senderId 추출
   const { friendshipId, senderId } = notification.payload as {
     friendshipId: number;
-    senderId: number;
+    senderId: string;
   };
 
   // 두 값이 모두 존재하는지 확인
@@ -59,12 +59,18 @@ export async function PATCH(request: Request) {
     //notification에서 해당 알림 삭제
     await prisma.notification.delete({ where: { id: notificationId } });
 
-    //moaNotification으로 @@님과 친구가 되었습니다 read true상태로 추가하기
+    //moaNotification으로 -님과 친구가 되었습니다 read true상태로 추가
+    //친구 닉네임 조회
+    const friendUser = await prisma.user.findUnique({
+      where: { id: senderId },
+      select: { nickname: true },
+    });
+    const friendNickname = friendUser?.nickname || "알 수 없음";
     await prisma.notification.create({
       data: {
         userId: session.user.id,
         type: "FROM_MOA",
-        message: "님과 친구가 되었습니다.",
+        message: `${friendNickname}님과 친구가 되었습니다.`,
         read: true,
       },
     });

--- a/src/app/api/notification/friend-request/route.ts
+++ b/src/app/api/notification/friend-request/route.ts
@@ -1,0 +1,136 @@
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/authoptions";
+import { Session } from "next-auth"; // Session 타입 임포트
+import { NextResponse } from "next/server";
+import { error } from "console";
+
+//친구 요청 수락
+export async function PATCH(request: Request) {
+  const session = (await getServerSession(authOptions)) as Session | null;
+  if (!session || !session.user) {
+    return NextResponse.json(
+      { error: "인증되지 않은 사용자입니다." },
+      { status: 401 }
+    );
+  }
+
+  //notificationId값 받아오기
+  const { notificationId } = await request.json();
+  if (!notificationId) {
+    return NextResponse.json(
+      { error: "notification ID값이 필요합니다" },
+      { status: 400 }
+    );
+  }
+
+  //해당 알림에서 payload값 받아오기기
+  const notification = await prisma.notification.findUnique({
+    where: { id: notificationId },
+    select: { payload: true },
+  });
+  if (!notification || !notification.payload) {
+    return NextResponse.json(
+      { error: "해당하는 알림이 없습니다(payload)" },
+      { status: 400 }
+    );
+  }
+
+  // payload값에서 friendshipId와 senderId 추출
+  const { friendshipId, senderId } = notification.payload as {
+    friendshipId: number;
+    senderId: number;
+  };
+
+  // 두 값이 모두 존재하는지 확인
+  if (friendshipId == null || senderId == null) {
+    return NextResponse.json(
+      { error: "payload에 friendshipId와 senderId가 모두 필요합니다." },
+      { status: 400 }
+    );
+  }
+  try {
+    //friendList 테이블에서 Pending 상태 Accepted로 전환
+    await prisma.friendship.update({
+      where: { id: friendshipId },
+      data: { status: "ACCEPTED" },
+    });
+
+    //notification에서 해당 알림 삭제
+    await prisma.notification.delete({ where: { id: notificationId } });
+
+    //moaNotification으로 @@님과 친구가 되었습니다 read true상태로 추가하기
+    await prisma.notification.create({
+      data: {
+        userId: session.user.id,
+        type: "FROM_MOA",
+        message: "님과 친구가 되었습니다.",
+        read: true,
+      },
+    });
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("친구 요청 수락 처리 중 오류 발생:", error);
+    return NextResponse.json(
+      { error: "친구 요청 수락 처리 중 오류 발생" },
+      { status: 500 }
+    );
+  }
+}
+
+//친구 요청 거절
+export async function DELETE(request: Request) {
+  const session = (await getServerSession(authOptions)) as Session | null;
+  if (!session || !session.user) {
+    return NextResponse.json(
+      { error: "인증되지 않은 사용자입니다." },
+      { status: 401 }
+    );
+  }
+
+  //notificationId값 받아오기
+  const { notificationId } = await request.json();
+  if (!notificationId) {
+    return NextResponse.json(
+      { error: "notification ID값이 필요합니다" },
+      { status: 400 }
+    );
+  }
+
+  //해당 알림 payload값 받아오기
+  const notification = await prisma.notification.findUnique({
+    where: { id: notificationId },
+    select: { payload: true },
+  });
+  if (!notification || !notification.payload) {
+    return NextResponse.json(
+      { error: "해당하는 알림이 없습니다(payload)" },
+      { status: 400 }
+    );
+  }
+
+  // payload값을 통해 friendshipId 추출
+  const { friendshipId } = notification.payload as { friendshipId: number };
+  if (!friendshipId || friendshipId == null) {
+    return NextResponse.json(
+      { error: "payload에 friendshipId가 존재하지 않습니다" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    //notification에서 해당 알림 삭제
+    await prisma.notification.delete({ where: { id: notificationId } });
+
+    //friendShip 테이블에서 해당 알림 삭제
+    await prisma.friendship.delete({ where: { id: friendshipId } });
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("친구 요청 거절 중 오류 발생:", error);
+    return NextResponse.json(
+      { error: "친구 요청 거절 중 오류 발생" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/notification/route.ts
+++ b/src/app/api/notification/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
       { status: 401 }
     );
   }
-  console.log("노티 콘솔 확인:", session);
+  // console.log("노티 콘솔 확인:", session);
   try {
     // 모든 알림 최근 순으로 조회
     const notifications = await prisma.notification.findMany({

--- a/src/hooks/useLetterCache.ts
+++ b/src/hooks/useLetterCache.ts
@@ -14,7 +14,10 @@ export default function useLetterCache() {
     //캐싱된 적 없다면(처음 요청이라면)
     const response = await fetch(`/api/letter/${letterId}`);
     if (!response.ok) {
-      throw new Error("편지 데이터 가져오는 중 오류 발생");
+      throw {
+        message: "편지 데이터 가져오는 중 오류 발생",
+        status: response.status,
+      };
     }
     const data = await response.json();
     //캐싱하기

--- a/src/lib/deletion.ts
+++ b/src/lib/deletion.ts
@@ -1,0 +1,32 @@
+import prisma from "./prisma";
+import type { Session } from "next-auth";
+//모아 박스 삭제 로직
+export async function deleteMoaBox(moaBoxId: number, session: Session) {
+  if (!session || !session.user) {
+    return { success: false, message: "인증되지 않은 사용자입니다." };
+  }
+
+  // 우편함 소유주 검증
+  const moaBox = await prisma.moaBox.findUnique({
+    where: { id: moaBoxId },
+    select: { ownerId: true },
+  });
+  if (!moaBox) {
+    return { success: false, message: "존재하지 않는 모아박스입니다." };
+  }
+  if (moaBox.ownerId !== session.user.id) {
+    return { success: false, message: "모아박스 소유주가 아닙니다." };
+  }
+
+  await prisma.moaBox.delete({ where: { id: moaBoxId } });
+  return { success: true };
+}
+
+//편지 삭제 로직
+export async function deleteLetter(letterId: number, session: Session) {
+  if (!session || !session.user) {
+    return { success: false, message: "인증되지 않은 사용자입니다." };
+  }
+  await prisma.letter.delete({ where: { id: letterId } });
+  return { success: true };
+}

--- a/src/styles/Alert.css
+++ b/src/styles/Alert.css
@@ -1,0 +1,6 @@
+div:where(.swal2-container).swal2-top,
+div:where(.swal2-container).swal2-center,
+div:where(.swal2-container).swal2-bottom {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  z-index: 10000 !important;
+}

--- a/src/styles/LetterModal.module.css
+++ b/src/styles/LetterModal.module.css
@@ -58,6 +58,26 @@
   filter: contrast(20);
   cursor: pointer;
 }
+.deleteButton {
+  transition: 0.2s ease;
+}
+.deleteButton:hover {
+  animation: deleteBtnRotate 0.5s ease-in-out;
+}
+/*삭제 버튼 애니메이션*/
+@keyframes deleteBtnRotate {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  45% {
+    transform: rotate(18deg);
+  }
+
+  75% {
+    transform: rotate(-10deg);
+  }
+}
 
 .spotifyContainer {
   display: flex;

--- a/src/styles/notification.module.css
+++ b/src/styles/notification.module.css
@@ -83,7 +83,7 @@
 }
 
 /*모아 소식함*/
-.my_notifications_section {
+.moa_notifications_section {
   padding-bottom: 12px;
 }
 .moa_notification {

--- a/src/styles/selectMoa.module.css
+++ b/src/styles/selectMoa.module.css
@@ -35,6 +35,9 @@
   border-radius: 20px;
   padding: 20px;
   transition: all 0.3s ease;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 }
 
 .card:hover {
@@ -52,24 +55,47 @@
   justify-content: center;
   align-items: center;
 }
-/*moaBox가 담긴 카드*/
-.moaCard {
-  background-color: var(--color-gray-200);
-}
 
 /*모아 박스 컨테이너*/
 .moaBoxContainer {
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+.moaBoxImage {
+  background-size: contain;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 380px;
+}
+.moaBoxName {
+  margin: 0 0 32px 0;
 }
 
 /*선택 됐을 때*/
 .selected {
-  background-color: var(--color-gray-400);
+  position: relative;
+  transform: scale(1.03);
+  box-shadow: 0 0 0 3px var(--color-black); /* 임시 색상*/
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
+
+/* .selected::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(59, 59, 59);
+  opacity: 0.5;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: background-color 0.3s ease;
+} */
 
 /*삭제 버튼*/
 .deleteBtnContainer {

--- a/src/types/moabox.ts
+++ b/src/types/moabox.ts
@@ -11,8 +11,14 @@ export type MoaBox = {
   letterCountPublic: boolean;
   createdAt: Date;
   updatedAt: Date;
-  backgroundDesignId: number | null;
-  mailBoxDesignId: number | null;
+  backgroundDesignId: number;
+  mailBoxDesignId: number;
+  backgroundDesign: {
+    imageURL: string;
+  };
+  mailBoxDesign: {
+    imageURL: string;
+  };
 };
 
 // 편지 미리보기(아이콘 형태일 때)

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -17,3 +17,10 @@ export interface MyNotification extends BaseNotification {
     profileImage?: string;
   };
 }
+
+export interface Notifications {
+  notifications: {
+    myNotifications: MyNotification[];
+    moaNotifications: BaseNotification[];
+  };
+}


### PR DESCRIPTION
## 📌제목 : Feat : Add delete logic for select-moa/moaBox(letter) ➕ Add logic and refactor notification page

### ➡️PR 방향

- [ ] 초기(첫 푸시)  → select-moa/모아박스의 편지 삭제 로직 추가
- [x] 수정 →  상세 내용은 📝 **내용** 참고
  - Sidebar 아이템 순서 변경 (서비스 특성 상)  
  - Notification page.tsx를 RSC(Server Component)로 전환 (서버 측 데이터 패칭으로 변경)  
  - 하위 컴포넌트 RCC(Client Component) 추가  
  - 친구 수락/거절 요청 로직 추가


---

## 📝 **내용**

### <추가>
**UI**  
- 로딩 fallback 화면으로 사용될 `loading.tsx` 컴포넌트가 추가되었습니다.

**Feature**  
- **Select-moa:**  
  - 선택한 moaBox를 삭제하는 로직이 추가되었습니다.  
  - moaBox 조회 시 BackgroundImage와 MailBoxImage URL을 가져오는 로직이 추가되었습니다.
- **편지 삭제:**  
  - 편지 삭제 비즈니스 로직(`HandleDeleteLetter.tsx`) 컴포넌트가 추가되었습니다.  
  - moaBox 소유주 외 사용자가 편지 클릭 시 toast alert를 추가하였습니다.  
  - moaBox/Letter DELETE 로직은 `/libs` 아래 별도의 모듈로 분리하였습니다.
- **Notification 관련 로직:**  
  - **친구 신청 수락:**  
     - 수락 시, `friendship` 테이블의 Pending 상태를 Accepted로 업데이트  
     - 해당 FRIEND_REQUEST 알림을 `notification` 테이블에서 삭제  
     - 이후, `FROM_MOA` 타입의 알림을 새로 생성 (읽음(read)값은 true로 설정하여 추가 요청 방지)
  - **친구 신청 거절:**  
     - `friendship` 테이블의 해당 레코드를 삭제한 후, `notification` 테이블의 관련 알림도 삭제
  - **마이 모아 읽음 처리:**  
     - Notification 페이지에 접근 시, 읽지 않은(not read) 알림이 있다면 useEffect를 통해 일괄 `read: true` 처리

### <수정>
- Notification 페이지 내 일부 오타 수정 (CSS 클래스명, import 경로 등)
- Notification의 page.tsx를 RSC(Server Component)로 전환하여 서버 데이터 패칭 방식으로 재작성 후, 하위 컴포넌트인 `NotificationPageClient.tsx`로 분리
- 중복되는 Notification 인터페이스를 `/types/notification`로 분리하고, 기존의 코드는 해당 타입을 import하여 사용하도록 변경
- 중간중간 있던 테스트용 콘솔 로그 등 불필요한 코드 제거

---

#### ⛓️연결된 이슈 :

closes
