### PR TITLE
feat : Moa-166 Add alert context and custom css for sweet alert

### DIFF
--- a/src/app/[year]/(components)/common/Navbar.tsx
+++ b/src/app/[year]/(components)/common/Navbar.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useNavigationContext } from "@/contexts/NavigationContext";
+import { useAlertContext } from "@/contexts/AlertContext";
+import { signIn } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
 import logo from "../../../../../public/assets/icons/nav_sidebar/nav_logo.svg";
@@ -8,6 +10,7 @@ import styles from "../../../../styles/navbar.module.css";
 
 export default function Navbar() {
   const { isLoggedIn, isOpen, setIsOpen } = useNavigationContext();
+  const { showConfirmModal } = useAlertContext();
   return (
     <>
       <nav className={styles.navbar}>
@@ -33,7 +36,17 @@ export default function Navbar() {
             </Link>
           ) : (
             <div
-              onClick={() => alert("로그인 후 사용 가능합니다?")}
+              onClick={() => {
+                showConfirmModal({
+                  icon: "정보",
+                  message: "로그인 페이지로 이동하시겠습니까?",
+                  confirmMessage: "로그인 후 이용 가능합니다",
+                  skipFollowUpAlert: true,
+                  onConfirm: () => {
+                    signIn(undefined, { callbackUrl: "/auth/login" });
+                  },
+                });
+              }}
               className={styles.notification_icon}
             >
               <Image

--- a/src/app/[year]/(components)/common/Sidebar.tsx
+++ b/src/app/[year]/(components)/common/Sidebar.tsx
@@ -4,6 +4,7 @@ import { signIn } from "next-auth/react";
 import { useNavigationContext } from "@/contexts/NavigationContext";
 import Link from "next/link";
 import Image, { StaticImageData } from "next/image";
+import { useAlertContext } from "@/contexts/AlertContext";
 //아이콘------------------------------------------------------------------------------
 import my_page from "../../../../../public/assets/icons/nav_sidebar/mypage_icon.svg";
 import select_moa from "../../../../../public/assets/icons/nav_sidebar/moa_select_icon.svg";
@@ -27,6 +28,7 @@ export default function Sidebar() {
   //전역에서 불러오기
   const { isOpen, setIsOpen, userName, isLoggedIn, userEmail } =
     useNavigationContext();
+  const { showConfirmModal, showAlert } = useAlertContext();
 
   // 사이드바 메뉴들
   const sidebarItems: SidebarItem[] = [
@@ -119,8 +121,15 @@ export default function Sidebar() {
                       className={styles.sidebar_item}
                       onClick={e => {
                         e.preventDefault();
-                        // 원하는 동작 (예: signIn 호출)
-                        signIn(undefined, { callbackUrl: "/auth/login" });
+                        showConfirmModal({
+                          icon: "정보",
+                          message: "로그인 페이지로 이동하시겠습니까?",
+                          confirmMessage: "로그인 후 이용 가능합니다",
+                          skipFollowUpAlert: true,
+                          onConfirm: () => {
+                            signIn(undefined, { callbackUrl: "/auth/login" });
+                          },
+                        });
                         setIsOpen(false);
                       }}
                     >

--- a/src/app/[year]/friendlist/(components)/FriendListContent.tsx
+++ b/src/app/[year]/friendlist/(components)/FriendListContent.tsx
@@ -5,7 +5,7 @@ import Modal from "../../(components)/common/Modal";
 import FriendInfo from "./FriendInfo";
 import friendListIcon from "@/../public/assets/icons/nav_sidebar/friend_list_icon.svg";
 import NoFriendImg from "@/../public/assets/broke_cat.svg";
-import styles from "@/styles/notification.module.css";
+import styles from "@/styles/friendlist.module.css";
 
 interface Friend {
   id: string;

--- a/src/app/[year]/layout.tsx
+++ b/src/app/[year]/layout.tsx
@@ -5,6 +5,7 @@ import Sidebar from "./(components)/common/Sidebar";
 //전역 관리
 import { NavigationProvider } from "@/contexts/NavigationContext";
 import ModalProvider from "@/contexts/ModalContext";
+import { AlertProvider } from "@/contexts/AlertContext";
 
 export default function YearSeasonLayout({
   children,
@@ -14,14 +15,16 @@ export default function YearSeasonLayout({
   return (
     <>
       <BackgroundLayout>
-        {/* 앱웹뷰 범위 내에서 작동하도록 현재 위치에 modal provider배치 */}
-        <ModalProvider>
-          <NavigationProvider>
-            <Navbar />
-            <Sidebar />
-            {children}
-          </NavigationProvider>
-        </ModalProvider>
+        <AlertProvider>
+          {/* 앱웹뷰 범위 내에서 작동하도록 현재 위치에 modal provider배치 */}
+          <ModalProvider>
+            <NavigationProvider>
+              <Navbar />
+              <Sidebar />
+              {children}
+            </NavigationProvider>
+          </ModalProvider>
+        </AlertProvider>
       </BackgroundLayout>
     </>
   );

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
@@ -58,7 +58,7 @@ export default function HandleAddFriend(props: Props) {
     if (!nickname) return; //닉네임이 없다면
     showConfirmModal({
       icon: "질문",
-      message: `${nickname}님께 친구 요청을 보내시겠습니까?`,
+      confirmMessage: `${nickname}님께 친구 요청을 보내시겠습니까?`,
       skipFollowUpAlert: true,
       onConfirm: async () => {
         setLoading(true);

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
@@ -2,7 +2,7 @@
 "use client";
 import { PropsWithChildren, useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Swal from "sweetalert2";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 interface Props extends PropsWithChildren {
   targetId: string;
@@ -21,6 +21,7 @@ export default function HandleAddFriend(props: Props) {
   const [nickname, setNickname] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const { showConfirmModal, showAlert } = useAlertContext();
 
   //닉네임불러오기
   useEffect(() => {
@@ -39,63 +40,86 @@ export default function HandleAddFriend(props: Props) {
     fetchNickname();
   }, [targetId]);
 
-  const clickHandler = useCallback(async () => {
+  const clickHandler = useCallback(() => {
     // 친구 요청한 사람이 로그인 되어있지 않다면
     if (!isAuthenticated) {
-      await Swal.fire({
-        icon: "warning",
-        text: "로그인이 필요합니다. 로그인 페이지로 이동합니다.",
+      showConfirmModal({
+        icon: "정보",
+        confirmMessage: "로그인이 필요합니다",
+        message: "로그인 페이지로 이동하시겠습니까?",
+        skipFollowUpAlert: true,
+        onConfirm: () => {
+          router.push("/auth/login");
+        },
       });
-      router.push("/auth/login");
       return;
     }
     if (loading) return; // 중복 요청 방지
     if (!nickname) return; //닉네임이 없다면
-    const result = await Swal.fire({
-      text: `${nickname}님께 친구 요청을 보내시겠습니까?`,
-      icon: "question",
-      showCancelButton: true,
-      confirmButtonColor: "#ff8473",
-      cancelButtonColor: "#aeaeae",
-      confirmButtonText: "확인",
-      cancelButtonText: "취소",
+    showConfirmModal({
+      icon: "질문",
+      message: `${nickname}님께 친구 요청을 보내시겠습니까?`,
+      skipFollowUpAlert: true,
+      onConfirm: async () => {
+        setLoading(true);
+        try {
+          //친구 요청 전송
+          const response = await fetch(`/2025/moa/mymoa/${moaBoxId}/api`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              targetUserId: targetId,
+            }),
+          });
+          const data = await response.json();
+          if (data.success) {
+            showAlert("친구 요청이 전송되었습니다!", "성공");
+            router.refresh(); //페이지 새로고침
+          } else {
+            console.log(data.code);
+            showAlert(
+              errorMessages[data.code] || errorMessages.DEFAULT,
+              "경고"
+            );
+          }
+        } catch (error) {
+          console.error("친구 요청 중 에러 발생!", error);
+        } finally {
+          setLoading(false);
+        }
+      },
     });
 
-    if (result.isConfirmed) {
-      setLoading(true);
-      try {
-        //친구 요청 전송
-        const response = await fetch(`/2025/moa/mymoa/${moaBoxId}/api`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            targetUserId: targetId,
-          }),
-        });
+    //   try {
+    //     //친구 요청 전송
+    //     const response = await fetch(`/2025/moa/mymoa/${moaBoxId}/api`, {
+    //       method: "POST",
+    //       headers: { "Content-Type": "application/json" },
+    //       body: JSON.stringify({
+    //         targetUserId: targetId,
+    //       }),
+    //     });
 
-        const data = await response.json();
-        if (data.success) {
-          Swal.fire({
-            icon: "success",
-            text: "친구 요청이 전송되었습니다!",
-          });
-        } else {
-          console.log(data.code);
-          Swal.fire({
-            icon: "warning",
-            text: errorMessages[data.code], //errir nessages에서 에러문구 출력
-          });
-        }
-      } catch (error) {
-        console.error("친구 요청 중 에러 발생!", error);
-        Swal.fire({
-          icon: "warning",
-          text: errorMessages.DEFAULT,
-        });
-      } finally {
-        setLoading(false);
-      }
-    }
+    //     const data = await response.json();
+    //     if (data.success) {
+    //       Swal.fire({
+    //         icon: "success",
+    //         text: "친구 요청이 전송되었습니다!",
+    //       });
+    //     } else {
+    //       console.log(data.code);
+    //       Swal.fire({
+    //         icon: "warning",
+    //         text: errorMessages[data.code], //errir nessages에서 에러문구 출력
+    //       });
+    //     }
+    //   } catch (error) {
+    //     console.error("친구 요청 중 에러 발생!", error);
+    //     Swal.fire({
+    //       icon: "warning",
+    //       text: errorMessages.DEFAULT,
+    //     });
+    //   }
   }, [nickname, moaBoxId, targetId, loading, isAuthenticated, router]);
 
   return <div onClick={clickHandler}>{children}</div>;

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React, { PropsWithChildren, ReactElement } from "react";
 import { useAlertContext } from "@/contexts/AlertContext";
+import { useRouter } from "next/navigation";
+import { useLetterModalContext } from "@/contexts/LetterModalContext";
 
 interface Props extends PropsWithChildren {
   children: ReactElement;
@@ -9,6 +11,8 @@ interface Props extends PropsWithChildren {
 
 export default function HandleDeleteLetter({ children, letterId }: Props) {
   const { showAlert, showConfirmModal } = useAlertContext();
+  const { closeLetterModal } = useLetterModalContext();
+  const router = useRouter();
 
   const clickHandler = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -21,6 +25,8 @@ export default function HandleDeleteLetter({ children, letterId }: Props) {
           const res = await fetch(`/api/letter/${letterId}`, {
             method: "DELETE",
           });
+          router.refresh();
+          closeLetterModal(); //편지 모달 닫기
         } catch (error) {
           console.error("편지 삭제 중 문제 발생", error);
           showAlert("삭제 중 오류가 발생했습니다.", "오류");

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -22,7 +22,7 @@ export default function HandleDeleteLetter({ children, letterId }: Props) {
       confirmMessage: "편지를 삭제하시겠습니까?",
       onConfirm: async () => {
         try {
-          const res = await fetch(`/api/letter/${letterId}`, {
+          await fetch(`/api/letter/${letterId}`, {
             method: "DELETE",
           });
           router.refresh();

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleDeleteLetter.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { PropsWithChildren, ReactElement } from "react";
-import { AlertProvider } from "@/app/[year]/(components)/common/Alert";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 interface Props extends PropsWithChildren {
   children: ReactElement;
@@ -8,35 +8,32 @@ interface Props extends PropsWithChildren {
 }
 
 export default function HandleDeleteLetter({ children, letterId }: Props) {
-  return (
-    <AlertProvider>
-      {({ showAlert, showConfirmModal }) => {
-        const clickHandler = async (e: React.MouseEvent) => {
-          e.stopPropagation();
-          showConfirmModal({
-            message: "삭제한 편지는 복구할 수 없습니다.",
-            confirmMessage: "편지를 삭제하시겠습니까?",
-            onConfirm: async () => {
-              try {
-                const res = await fetch(`/api/letter/${letterId}`, {
-                  method: "DELETE",
-                });
-              } catch (error) {
-                console.error("편지 삭제 중 문제 발생", error);
-                showAlert("삭제 중 오류가 발생했습니다.", "오류");
-              }
-            },
-            onCancel: () => {
-              showAlert("삭제가 취소되었습니다.", "정보");
-            },
-          });
-        };
+  const { showAlert, showConfirmModal } = useAlertContext();
 
-        const childWithHandler = React.cloneElement(children, {
-          onClick: clickHandler,
-        });
-        return childWithHandler;
-      }}
-    </AlertProvider>
-  );
+  const clickHandler = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    showConfirmModal({
+      icon: "경고",
+      message: "삭제한 편지는 복구할 수 없습니다.",
+      confirmMessage: "편지를 삭제하시겠습니까?",
+      onConfirm: async () => {
+        try {
+          const res = await fetch(`/api/letter/${letterId}`, {
+            method: "DELETE",
+          });
+        } catch (error) {
+          console.error("편지 삭제 중 문제 발생", error);
+          showAlert("삭제 중 오류가 발생했습니다.", "오류");
+        }
+      },
+      onCancel: () => {
+        showAlert("삭제가 취소되었습니다.", "정보");
+      },
+    });
+  };
+
+  const childWithHandler = React.cloneElement(children, {
+    onClick: clickHandler,
+  });
+  return childWithHandler;
 }

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleWriteLetter.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleWriteLetter.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { PropsWithChildren, ReactElement } from "react";
 import { useRouter } from "next/navigation";
-import Swal from "sweetalert2";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 interface Props extends PropsWithChildren {
   children: ReactElement;
@@ -12,26 +12,22 @@ interface Props extends PropsWithChildren {
 export default function HandleCreateLetter(props: Props) {
   const { children, allowAnonymous, isAuthenticated } = props;
   const router = useRouter();
+  const { showConfirmModal } = useAlertContext();
+
   const clickHandler = async (e: React.MouseEvent) => {
     e.stopPropagation();
     // 친구 요청한 사람이 로그인 되어있지 않다면
     if (!allowAnonymous && !isAuthenticated) {
-      const result = await Swal.fire({
-        icon: "warning",
-        text: "로그인이 필요합니다. 로그인하시겠습니까?",
-        showCancelButton: true,
-        confirmButtonColor: "#ff8473",
-        cancelButtonColor: "#aeaeae",
-        confirmButtonText: "확인",
-        cancelButtonText: "취소",
+      showConfirmModal({
+        icon: "정보",
+        confirmMessage: "로그인이 필요합니다",
+        message: "로그인 페이지로 이동하시겠습니까?",
+        skipFollowUpAlert: true,
+        onConfirm: () => {
+          router.push("/auth/login");
+        },
       });
-      if (result.isConfirmed) {
-        router.push("/auth/login");
-        return;
-      }
-      if (result.isDismissed) {
-        return;
-      }
+      return;
     }
     router.push("/2025/create-letter");
   };

--- a/src/app/[year]/moa/mymoa/(components)/(features)/ShareLinkContent.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/ShareLinkContent.tsx
@@ -7,6 +7,7 @@ import lineIcon from "@/../../public/assets/icons/sharelink_modal/line.svg";
 import facebookIcon from "@/../../public/assets/icons/sharelink_modal/facebook.svg";
 import xIcon from "@/../../public/assets/icons/sharelink_modal/x_sns.svg";
 import Swal from "sweetalert2";
+import { useAlertContext } from "@/contexts/AlertContext";
 import styles from "@/styles/modal.module.css";
 import NotFound from "@/app/[year]/(components)/not-found";
 
@@ -47,6 +48,7 @@ const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export default function ShareLinkModal() {
   const { id } = useParams();
+  const { showAlert } = useAlertContext();
   if (!id) {
     return NotFound();
   }
@@ -89,12 +91,7 @@ export default function ShareLinkModal() {
       });
     } catch (e) {
       console.error(e);
-      Swal.fire({
-        title: "Error",
-        text: "복사 중 문제가 생겼습니다",
-        icon: "error",
-        confirmButtonText: "확인",
-      });
+      showAlert("복사 중 오류가 발생했습니다", "오류");
     }
   };
   //카카오톡 공유하기

--- a/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
+++ b/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
@@ -41,7 +41,7 @@ export default function SelectCarousel({
       confirmMessage: "편지를 삭제하시겠습니까?",
       onConfirm: async () => {
         try {
-          const res = await fetch(`/api/moa/${moaBoxId}`, {
+          await fetch(`/api/moa/${moaBoxId}`, {
             method: "DELETE",
           });
           router.refresh();

--- a/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
+++ b/src/app/[year]/moa/select-moa/(components)/SelectCarousel.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 //Swiper 라이브러리 import
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";

--- a/src/app/[year]/notification/(components)/NotificationContent.tsx
+++ b/src/app/[year]/notification/(components)/NotificationContent.tsx
@@ -13,10 +13,11 @@ import {
   MyNotification,
   Notifications,
 } from "@/types/notification";
-import Swal from "sweetalert2"; //임시시
+import { useAlertContext } from "@/contexts/AlertContext";
 
 export default function NotificationContent({ notifications }: Notifications) {
   const router = useRouter();
+  const { showAlert, showConfirmModal } = useAlertContext();
   //알림 종류에 따라 분류
   //내 소식
   const myNotifications: MyNotification[] = notifications.myNotifications;
@@ -52,86 +53,62 @@ export default function NotificationContent({ notifications }: Notifications) {
   // 내 소식: 친구 요청 수락
   const handleAccept = async (e: React.MouseEvent, notificationId: number) => {
     e.preventDefault();
-    const result = await Swal.fire({
-      icon: "question",
-      text: "친구 요청을 수락하시겠습니까?",
-      showCancelButton: true,
-      confirmButtonColor: "#ff8473",
-      cancelButtonColor: "#aeaeae",
-      confirmButtonText: "확인",
-      cancelButtonText: "취소",
-    });
-
-    if (!result.isConfirmed) return;
-    if (result.isConfirmed) {
-      try {
-        const res = await fetch("/api/notification/friend-request", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ notificationId }),
-        });
-        const data = await res.json();
-        if (data.success) {
-          await Swal.fire({
-            icon: "success",
-            text: "친구 요청이 수락되었습니다",
+    showConfirmModal({
+      message: "친구 요청을 수락하시겠습니까?",
+      icon: "질문", // 확인 모달에 사용할 icon (AlertContext에서 지정한 타입 중 하나)
+      onConfirm: async () => {
+        try {
+          const res = await fetch("/api/notification/friend-request", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ notificationId }),
           });
-        } else {
-          Swal.fire({
-            icon: "error",
-            text: "수락 중 문제가 발생했습니다",
-          });
+          const data = await res.json();
+          if (data.success) {
+            showAlert("친구 요청이 수락되었습니다", "성공");
+            router.refresh();
+          } else {
+            showAlert("수락 중 문제가 발생했습니다", "오류");
+          }
+        } catch (error) {
+          console.error("친구 요청 수락 중 문제 발생", error);
         }
-      } catch (error) {
-        console.error("친구 요청 수락 중 문제 발생", error);
-        Swal.fire({
-          icon: "error",
-          text: "수락 중 문제가 발생했습니다.",
-        });
-      }
-    }
+      },
+      onCancel: () => {
+        showAlert("수락이 취소되었습니다", "정보");
+      },
+    });
   };
 
   // 내 소식 : 친구 요청 거절
   const handleReject = async (e: React.MouseEvent, notificationId: number) => {
     e.preventDefault();
-    const result = await Swal.fire({
-      icon: "warning",
-      text: "친구 요청을 거절하시겠습니까? 해당 작업은 되돌릴 수 없습니다.",
-      showCancelButton: true,
-      confirmButtonColor: "#ff8473",
-      cancelButtonColor: "#aeaeae",
-      confirmButtonText: "확인",
-      cancelButtonText: "취소",
-    });
-    if (!result.isConfirmed) return;
-    if (result.isConfirmed) {
-      try {
-        const res = await fetch(`/api/notification/friend-request`, {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ notificationId }),
-        });
-        const data = await res.json();
-
-        if (data.success) {
-          Swal.fire({ icon: "info", text: "친구 요청이 거절되었습니다" });
-          router.refresh();
-          return;
-        } else {
-          Swal.fire({
-            icon: "warning",
-            text: "요청 거절 중 문제가 발생했습니다",
+    showConfirmModal({
+      message: "친구 요청을 거절하시겠습니까? 해당 작업은 되돌릴 수 없습니다.",
+      icon: "경고",
+      onConfirm: async () => {
+        try {
+          const res = await fetch("/api/notification/friend-request", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ notificationId }),
           });
+          const data = await res.json();
+          if (data.success) {
+            showAlert("친구 요청이 거절되었습니다", "정보");
+            router.refresh();
+          } else {
+            showAlert("요청 거절 중 문제가 발생했습니다", "경고");
+          }
+        } catch (error) {
+          console.error("친구 요청 거절 중 문제 발생", error);
+          showAlert("요청 거절 중 문제가 발생했습니다", "경고");
         }
-      } catch (error) {
-        console.error("친구 요청 거절 중 문제 발생", error);
-        Swal.fire({
-          icon: "warning",
-          text: "요청 거절 중 문제가 발생했습니다",
-        });
-      }
-    }
+      },
+      onCancel: () => {
+        showAlert("요청이 취소되었습니다.", "정보");
+      },
+    });
   };
 
   return (

--- a/src/app/[year]/notification/(components)/NotificationContent.tsx
+++ b/src/app/[year]/notification/(components)/NotificationContent.tsx
@@ -54,7 +54,7 @@ export default function NotificationContent({ notifications }: Notifications) {
   const handleAccept = async (e: React.MouseEvent, notificationId: number) => {
     e.preventDefault();
     showConfirmModal({
-      message: "친구 요청을 수락하시겠습니까?",
+      confirmMessage: "친구 요청을 수락하시겠습니까?",
       icon: "질문",
       skipFollowUpAlert: true,
       onConfirm: async () => {
@@ -85,7 +85,8 @@ export default function NotificationContent({ notifications }: Notifications) {
   const handleReject = async (e: React.MouseEvent, notificationId: number) => {
     e.preventDefault();
     showConfirmModal({
-      message: "친구 요청을 거절하시겠습니까? 해당 작업은 되돌릴 수 없습니다.",
+      confirmMessage: "친구 요청을 거절하시겠습니까?",
+      message: "삭제된 요청은 복구할 수 없습니다.",
       icon: "경고",
       skipFollowUpAlert: true,
       onConfirm: async () => {

--- a/src/app/[year]/notification/(components)/NotificationContent.tsx
+++ b/src/app/[year]/notification/(components)/NotificationContent.tsx
@@ -55,7 +55,8 @@ export default function NotificationContent({ notifications }: Notifications) {
     e.preventDefault();
     showConfirmModal({
       message: "친구 요청을 수락하시겠습니까?",
-      icon: "질문", // 확인 모달에 사용할 icon (AlertContext에서 지정한 타입 중 하나)
+      icon: "질문",
+      skipFollowUpAlert: true,
       onConfirm: async () => {
         try {
           const res = await fetch("/api/notification/friend-request", {
@@ -86,6 +87,7 @@ export default function NotificationContent({ notifications }: Notifications) {
     showConfirmModal({
       message: "친구 요청을 거절하시겠습니까? 해당 작업은 되돌릴 수 없습니다.",
       icon: "경고",
+      skipFollowUpAlert: true,
       onConfirm: async () => {
         try {
           const res = await fetch("/api/notification/friend-request", {

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -13,7 +13,7 @@ export interface AlertContextValue {
     type?: "성공" | "정보" | "경고" | "질문" | "오류"
   ) => void;
   showConfirmModal: (options: {
-    message: string;
+    message?: string;
     icon: "성공" | "정보" | "경고" | "질문" | "오류";
     confirmMessage?: string;
     skipFollowUpAlert?: boolean; //showConfirmModal 후속 알림 표시할 지
@@ -47,7 +47,17 @@ export const AlertProvider = ({
         title: title,
         text: text,
         icon: title === "취소" ? typeToIconMap["정보"] : typeToIconMap["성공"],
-        confirmButtonColor: "var(--color-black)",
+        confirmButtonText: "확인",
+        backdrop: "rgba(0,0,0,0.3)",
+        buttonsStyling: false, //버튼 기본 스타일 제거
+        customClass: {
+          popup: "swal-popup",
+          icon: "swal-icon",
+          title: "swal-title",
+          htmlContainer: "swal-text",
+          confirmButton: "custom-button confirm",
+          actions: "swal-actions-one",
+        },
       });
     }
   };
@@ -62,28 +72,47 @@ export const AlertProvider = ({
       icon: typeToIconMap[type],
       backdrop: "rgba(0,0,0,0.3)",
       showConfirmButton: true,
-      confirmButtonColor: "var(--color-black)",
       confirmButtonText: "확인",
+      buttonsStyling: false, // 기본 스타일 제거
+      customClass: {
+        popup: "swal-popup",
+        icon: "swal-icon",
+        title: "swal-title",
+        htmlContainer: "swal-text",
+        confirmButton: "custom-button confirm",
+        actions: "swal-actions-one",
+      },
     });
   };
 
   const showConfirmModal = (options: {
-    message: string;
+    message?: string;
     icon: string;
     confirmMessage?: string;
     onConfirm?: () => void;
     onCancel?: () => void;
-    skipFollowUpAlert?: boolean; //showConfirmModal 후속 알림 표시할 지
+    skipFollowUpAlert?: boolean;
   }) => {
     Swal.fire({
-      title: options.confirmMessage || "진행하시겠습니까?",
+      title: options.confirmMessage,
       text: options.message,
       icon: typeToIconMap[options.icon],
       showCancelButton: true,
-      confirmButtonColor: "var(--color-black)",
-      cancelButtonColor: "#aeaeae",
+      // confirmButtonColor: "var(--color-gray-500)",
+      cancelButtonColor: "transparent",
+      backdrop: "rgba(0,0,0,0.3)",
       confirmButtonText: "확인",
       cancelButtonText: "취소",
+      reverseButtons: true,
+      customClass: {
+        popup: "swal-popup",
+        icon: "swal-icon",
+        title: "swal-title",
+        htmlContainer: "swal-text",
+        actions: "swal-actions",
+        confirmButton: "custom-button confirm",
+        cancelButton: "custom-button cancel",
+      },
     }).then(result => {
       if (result.isConfirmed) {
         showFollowUpAlert(
@@ -101,6 +130,7 @@ export const AlertProvider = ({
       }
     });
   };
+
   const value: AlertContextValue = { showAlert, showConfirmModal };
   return (
     <AlertContext.Provider value={value}>{children}</AlertContext.Provider>

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -1,0 +1,99 @@
+"use client";
+import React, { ReactNode, createContext, useContext } from "react";
+import Swal from "sweetalert2";
+import "@/styles/Alert.css";
+
+//사용 예제
+//showConfirmModal({icon: "경고", message: "삭제한 편지는 복구할 수 없습니다.",confirmMessage: "편지를 삭제하시겠습니까?".. })
+
+//AlertContext에서 제공할 값들
+export interface AlertContextValue {
+  showAlert: (
+    message: string,
+    type?: "성공" | "정보" | "경고" | "오류"
+  ) => void;
+  showConfirmModal: (options: {
+    message: string;
+    icon: string;
+    confirmMessage?: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  }) => void;
+}
+
+const AlertContext = createContext<AlertContextValue | undefined>(undefined);
+
+// AlertProvider는 children을 ReactNode로 받음
+export interface AlertProviderProps {
+  children: ReactNode;
+}
+
+export const AlertProvider = ({
+  children,
+}: AlertProviderProps): JSX.Element => {
+  const typeToIconMap = {
+    성공: "success",
+    정보: "info",
+    경고: "warning",
+    오류: "error",
+  } as const;
+
+  const showAlert = (
+    message: string,
+    type: "성공" | "정보" | "경고" | "오류" = "정보"
+  ) => {
+    Swal.fire({
+      title: type,
+      html: message,
+      icon: typeToIconMap[type],
+      backdrop: "rgba(0,0,0,0.3)",
+      showConfirmButton: true,
+    });
+  };
+
+  const showConfirmModal = (options: {
+    message: string;
+    icon: string;
+    confirmMessage?: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  }) => {
+    Swal.fire({
+      title: options.confirmMessage || "진행하시겠습니까?",
+      text: options.message,
+      icon: typeToIconMap[options.icon],
+      showCancelButton: true,
+      confirmButtonColor: "var(--color-black)",
+      cancelButtonColor: "#aeaeae",
+      confirmButtonText: "확인",
+      cancelButtonText: "취소",
+    }).then(result => {
+      if (result.isConfirmed) {
+        Swal.fire({
+          title: "완료되었습니다!",
+          text: options.message,
+          icon: typeToIconMap["성공"],
+        });
+        if (options.onConfirm) options.onConfirm();
+      } else if (result.dismiss === Swal.DismissReason.cancel) {
+        Swal.fire({
+          title: "취소",
+          text: "요청하신 작업이 취소되었습니다.",
+          icon: typeToIconMap["정보"],
+        });
+        if (options.onCancel) options.onCancel();
+      }
+    });
+  };
+  const value: AlertContextValue = { showAlert, showConfirmModal };
+  return (
+    <AlertContext.Provider value={value}>{children}</AlertContext.Provider>
+  );
+};
+export function useAlertContext() {
+  const context = useContext(AlertContext);
+  if (!context) {
+    throw new Error("Alert 전역 불러오는 중 문제 발생!");
+  }
+  return context;
+}

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -10,7 +10,7 @@ import "@/styles/Alert.css";
 export interface AlertContextValue {
   showAlert: (
     message: string,
-    type?: "성공" | "정보" | "경고" | "오류"
+    type?: "성공" | "정보" | "경고" | "질문" | "오류"
   ) => void;
   showConfirmModal: (options: {
     message: string;
@@ -35,12 +35,13 @@ export const AlertProvider = ({
     성공: "success",
     정보: "info",
     경고: "warning",
+    질문: "question",
     오류: "error",
   } as const;
 
   const showAlert = (
     message: string,
-    type: "성공" | "정보" | "경고" | "오류" = "정보"
+    type: "성공" | "정보" | "경고" | "질문" | "오류" = "정보"
   ) => {
     Swal.fire({
       title: type,
@@ -70,9 +71,9 @@ export const AlertProvider = ({
     }).then(result => {
       if (result.isConfirmed) {
         Swal.fire({
-          title: "완료되었습니다!",
-          text: options.message,
+          title: "성공적으로 완료되었습니다!",
           icon: typeToIconMap["성공"],
+          confirmButtonColor: "var(--color-black)",
         });
         if (options.onConfirm) options.onConfirm();
       } else if (result.dismiss === Swal.DismissReason.cancel) {
@@ -80,6 +81,7 @@ export const AlertProvider = ({
           title: "취소",
           text: "요청하신 작업이 취소되었습니다.",
           icon: typeToIconMap["정보"],
+          confirmButtonColor: "var(--color-black)",
         });
         if (options.onCancel) options.onCancel();
       }

--- a/src/styles/Alert.css
+++ b/src/styles/Alert.css
@@ -1,6 +1,16 @@
+/* z-index값 */
 div:where(.swal2-container).swal2-top,
 div:where(.swal2-container).swal2-center,
 div:where(.swal2-container).swal2-bottom {
   grid-template-columns: auto minmax(0, 1fr) auto;
   z-index: 10000 !important;
+}
+
+/*title 폰트 사이즈*/
+div:where(.swal2-container) h2:where(.swal2-title) {
+  font-size: 1.2rem !important;
+}
+/* text 폰트 사이즈 */
+div:where(.swal2-container) div:where(.swal2-html-container) {
+  font-size: 1em !important;
 }

--- a/src/styles/Alert.css
+++ b/src/styles/Alert.css
@@ -1,16 +1,73 @@
-/* z-index값 */
-div:where(.swal2-container).swal2-top,
-div:where(.swal2-container).swal2-center,
-div:where(.swal2-container).swal2-bottom {
-  grid-template-columns: auto minmax(0, 1fr) auto;
+/* 컨테이너 레벨 z-index (선택사항) */
+.swal2-container {
   z-index: 10000 !important;
 }
 
-/*title 폰트 사이즈*/
-div:where(.swal2-container) h2:where(.swal2-title) {
-  font-size: 1.2rem !important;
+/* 모달창 스타일 */
+.swal-popup {
+  border-radius: 20px !important;
+  width: 29em !important;
 }
-/* text 폰트 사이즈 */
-div:where(.swal2-container) div:where(.swal2-html-container) {
-  font-size: 1em !important;
+
+/* 아이콘 */
+.swal-icon {
+  font-size: 15px !important;
+  margin: 2.5em auto 0.8em !important;
+}
+
+/* 타이틀 */
+.swal-title {
+  font-size: 1.1rem !important;
+  padding: 1.2em 0 0.2em !important;
+}
+
+/* 본문 텍스트 */
+.swal-text {
+  font-size: 14px !important;
+  padding: 0.5em 1.6em 0.3em !important;
+}
+
+/* 액션 버튼 wrapper */
+.swal-actions {
+  display: flex;
+  justify-content: space-between;
+  width: 50% !important;
+  padding: 0 0 0.2em;
+  gap: 1rem;
+}
+
+/*액션 버튼이 1개일때*/
+.swal-actions-one {
+  display: flex;
+  width: 30% !important;
+  padding: 0 0 0.2em;
+}
+
+/* 버튼 공통 스타일 */
+.custom-button {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  border-radius: 24px;
+  transition: all 0.2s ease-in-out;
+  border: none;
+}
+
+/* 버튼별 색상 */
+/*확인 버튼*/
+.custom-button.confirm {
+  background-color: var(--color-black);
+  color: white;
+}
+.custom-button.confirm:hover {
+  background-color: var(--color-gray-700) !important;
+}
+
+/*취소 버튼*/
+.custom-button.cancel {
+  color: #2d3748;
+}
+.custom-button.cancel:hover {
+  background-color: var(--color-gray-200) !important;
+  color: white;
 }


### PR DESCRIPTION
## 📌제목 : feat : Moa-166 Add alert context and custom css for sweet alert

### ➡️PR 방향

- [x] 수정 → 
- 기존 작성 되어 있던 Alert.tsx를 토대로 `Alert Context API`를 추가했습니다.  
- 직접 import해서 Swal.fire를 사용하던 컴포넌트를 alert context API를 사용하도록 통일했습니다.
- **디자인은 계속 수정될 예정**입니다!(Alert.css를 통해 변경한 css를 `customClass`를 통해 전달 중이므로, 수정하고싶은 부분이 있다면 Alert.css 파일을 통하시면 됩니다)
- `/[year]/layout.tsx`에 AlertProvider를 전역으로 설정했으므로, 알림이 필요한 컴포넌트에서 provider로 
   감쌀 필요 없이 아래와 같이 사용할 수 있습니다! :
   **import { useAlertContext } from "@/contexts/AlertContext";**

    **const { showAlert, showConfirmModal } = useAlertContext();**


---
### 📝내용






### showAlert 

- `message(타이틀)`, `type(아이콘 타입)` 총 2개의 인자를 필수적으로 받으며 단순 내용 전달에 사용하기 좋습니다.
![image](https://github.com/user-attachments/assets/79eeed64-7339-4603-8d31-34a2236ac3ea)

**( 예시 이미지 1 )**
![image](https://github.com/user-attachments/assets/34332b79-c8e7-46cb-83ec-6867216ee69f)





### showConfirmModal

- `confirmMessage(타이틀)`, `message(상세 메세지)`, `icon(아이콘 타입)`, `onConfirm(승인 시 수행할 동작)`, `onCancel(취소 시 수행할 동작)`, **`skipFollowUpAlert**(후속 알림 표시 여부)`로, icon만 필수며 나머지는 선택적 인자로 받습니다.

- 사용자의 승인/거절 여부에 따라 **후속 동작을 추가할 때** 사용하기 좋습니다

-  **후속 알림**을 기본적으로 가지고 있기 때문에, 구체적인 후속 알림을 띄우고 싶은 경우 `skipFollowUpAlert를 true`로 설정한 뒤, 직접 showAlert를 추가하시면 됩니다**(예시 이미지 3 참고)**
       -> 해당 속성 추가 이유 : 확인을 눌렀을 때 후속 alert 없이 바로 동작을 수행해야하는 경우를(ex. 로그인 페이지로 redirect 
            etc.) 고려해 추가됐습니다.
![image](https://github.com/user-attachments/assets/807286da-f102-489d-b534-02e5916a6c4a)

**( 예시 이미지 2 )**
![image](https://github.com/user-attachments/assets/7c762554-a3ff-455a-b1e5-4e1dcc51d893)
기본 후속 알림 - 확인 시
![image](https://github.com/user-attachments/assets/36199642-fc90-4667-be0f-64a1bbbe9976)
기본 후속 알림 - 취소 시


**( 예시 이미지 3 - 직접 showAlert로 추가한 경우)**
![image](https://github.com/user-attachments/assets/a063bf07-4143-4814-be92-2d93d97ec5b1)

**(예시 코드)**
![image](https://github.com/user-attachments/assets/adb2f449-0c9e-4173-9b7c-d7f2f3da3f5b)

---

#### ⛓️연결된 이슈 :

closes MOA-166
