### PR TITLE
Feat : Moa-138 Add saved-moa page

### DIFF
--- a/src/app/[year]/(components)/common/Button.tsx
+++ b/src/app/[year]/(components)/common/Button.tsx
@@ -65,8 +65,8 @@ export const buttonColor = {
   `,
   //버튼 상호작용 x일 때
   blocked: css`
-    background-color: var(--color-gray-300);
-    color: var(--color-gray-500);
+    background-color: var(--color-gray-400);
+    color: var(--color-gray-300);
     font-weight: bold;
     cursor: default;
   `,

--- a/src/app/[year]/(components)/common/Sidebar.tsx
+++ b/src/app/[year]/(components)/common/Sidebar.tsx
@@ -6,11 +6,11 @@ import Link from "next/link";
 import Image, { StaticImageData } from "next/image";
 import { useAlertContext } from "@/contexts/AlertContext";
 //아이콘------------------------------------------------------------------------------
-import my_page from "../../../../../public/assets/icons/nav_sidebar/mypage_icon.svg";
+import my_page from "../../../../../public/assets/icons/nav_sidebar/friend_list_icon.svg";
 import select_moa from "../../../../../public/assets/icons/nav_sidebar/moa_select_icon.svg";
 import saved_moa from "../../../../../public/assets/icons/nav_sidebar/saved_moa_icon.svg";
 import sent_letter from "../../../../../public/assets/icons/nav_sidebar/sent_letter_icon.svg";
-import friend_list from "../../../../../public/assets/icons/nav_sidebar/friend_list_icon.svg";
+import friend_list from "../../../../../public/assets/icons/nav_sidebar/mypage_icon.svg";
 import copyright_img from "../../../../../public/assets/icons/nav_sidebar/sidebar_copyright.svg";
 import login_btn from "../../../../../public/assets/icons/sidebar_login_btn.svg";
 //css------------------------------------------------------------------------------
@@ -38,7 +38,12 @@ export default function Sidebar() {
       href: "/2025/moa/select-moa",
       icon: select_moa,
     },
-    { id: "2", label: "마이페이지", href: "/2025/mypage", icon: my_page },
+    {
+      id: "2",
+      label: "친구 목록",
+      href: "/2025/friendlist",
+      icon: friend_list,
+    },
     {
       id: "3",
       label: "지난모아 보관함",
@@ -52,12 +57,7 @@ export default function Sidebar() {
       href: "/2025/sent-letter",
       icon: sent_letter,
     },
-    {
-      id: "5",
-      label: "친구 목록",
-      href: "/2025/friendlist",
-      icon: friend_list,
-    },
+    { id: "5", label: "마이페이지", href: "/2025/mypage", icon: my_page },
   ];
 
   return (

--- a/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(features)/HandleAddFriend.tsx
@@ -120,7 +120,16 @@ export default function HandleAddFriend(props: Props) {
     //       text: errorMessages.DEFAULT,
     //     });
     //   }
-  }, [nickname, moaBoxId, targetId, loading, isAuthenticated, router]);
+  }, [
+    nickname,
+    moaBoxId,
+    targetId,
+    loading,
+    isAuthenticated,
+    router,
+    showAlert,
+    showConfirmModal,
+  ]);
 
   return <div onClick={clickHandler}>{children}</div>;
 }

--- a/src/app/[year]/moa/mymoa/(components)/(ui)/SpotifyWithDelay.tsx
+++ b/src/app/[year]/moa/mymoa/(components)/(ui)/SpotifyWithDelay.tsx
@@ -52,6 +52,7 @@ export default function SpotifyWithDelay({
         allow="encrypted-media"
         onLoad={handleLoad}
         style={{
+          borderRadius: "16px",
           opacity: showEmbed ? 1 : 0,
           transition: "opacity 0.5s ease-in-out",
         }}

--- a/src/app/[year]/moa/mymoa/[id]/page.tsx
+++ b/src/app/[year]/moa/mymoa/[id]/page.tsx
@@ -58,6 +58,10 @@ export default async function MyMoaBoxPage({ params }) {
   const mailBoxDesign = moaBox.mailBoxDesign?.imageURL;
   //모아 박스에 달린 모든 편지 불러오기
   const letters = moaBox.letters;
+
+  //모아박스 만료 여부 체크
+  const isExpired = new Date(moaBox.dueDate).getTime() <= Date.now();
+
   return (
     <>
       {/* 마이 모아 전체 배경 img */}
@@ -93,14 +97,19 @@ export default async function MyMoaBoxPage({ params }) {
                 icon={<Image src={downloadIcon} alt="share icon" />}
                 size="circle"
               ></Button>
-              <OpenShareLinkModal>
-                <Button
-                  label="공유하기"
-                  icon={<Image src={shareIcon} alt="share icon" />}
-                  size="medium"
-                  color="black"
-                />
-              </OpenShareLinkModal>
+              {isExpired ? ( //기념일 종료 됐을 시
+                <Button label="기념일 종료" size="medium" color="blocked" />
+              ) : (
+                //종료되지 않은 경우
+                <OpenShareLinkModal>
+                  <Button
+                    label="공유하기"
+                    icon={<Image src={shareIcon} alt="share icon" />}
+                    size="medium"
+                    color="black"
+                  />
+                </OpenShareLinkModal>
+              )}
             </>
           ) : (
             <>
@@ -125,17 +134,23 @@ export default async function MyMoaBoxPage({ params }) {
                   size="circle"
                 />
               </HandleAddFriend>
-              <HandleCreateLetter
-                allowAnonymous={moaBox.allowAnonymous}
-                isAuthenticated={!!session}
-              >
-                <Button
-                  label={"편지 작성하기"}
-                  icon={<Image src={penIcon} alt="pen icon" />}
-                  size="medium"
-                  color="black"
-                />
-              </HandleCreateLetter>
+              {isExpired ? (
+                //기념일 종료 시
+                <Button label="기념일 종료" size="medium" color="blocked" />
+              ) : (
+                //종료되지 않은 경우
+                <HandleCreateLetter
+                  allowAnonymous={moaBox.allowAnonymous}
+                  isAuthenticated={!!session}
+                >
+                  <Button
+                    label={"편지 작성하기"}
+                    icon={<Image src={penIcon} alt="pen icon" />}
+                    size="medium"
+                    color="black"
+                  />
+                </HandleCreateLetter>
+              )}
             </>
           )}
         </section>

--- a/src/app/[year]/moa/select-moa/[friendId]/page.tsx
+++ b/src/app/[year]/moa/select-moa/[friendId]/page.tsx
@@ -24,7 +24,7 @@ export default async function FriendSelectMoaPage({ params }) {
   });
 
   if (friendMoaBoxes.length === 0) {
-    //친구가 진행 중인 모아가 없을 때 화면(일단 notFound로 처리, 나중에 교체)
+    //친구가 진행 중인 모아가 없을 때 화면(나중에 교체 예정)
     return (
       <div
         style={{
@@ -37,7 +37,7 @@ export default async function FriendSelectMoaPage({ params }) {
         }}
       >
         <Image src={NoMoaImage} alt="no moa" width={180} />
-        <p>진행 중인 모아 박스스가 없습니다 ...</p>
+        <p>진행 중인 모아 박스가 없습니다 ...</p>
       </div>
     );
   }

--- a/src/app/[year]/moa/select-moa/page.tsx
+++ b/src/app/[year]/moa/select-moa/page.tsx
@@ -11,10 +11,11 @@ export default async function SelectMoaPage() {
   if (!session?.user) {
     redirect("/auth/login");
   }
-  //userId === ownerId인 모든 moaBox 필터해오기
+  //userId === ownerId고 dueDate를 넘기지 않은 모든 moaBox 필터해오기
   const userMoaBoxes = await prisma.moaBox.findMany({
     where: {
       ownerId: session.user.id,
+      dueDate: { gte: new Date() },
     },
     include: {
       backgroundDesign: { select: { imageURL: true } },

--- a/src/app/[year]/saved-moa/[id]/layout.tsx
+++ b/src/app/[year]/saved-moa/[id]/layout.tsx
@@ -1,0 +1,14 @@
+import Image from "next/image";
+import icon from "@/../public/assets/icons/nav_sidebar/saved_moa_icon.svg";
+import styles from "@/styles/selectMoa.module.css";
+export default function SavedMoaLayout({ children }) {
+  return (
+    <div className={styles.layoutContainer}>
+      <div className={styles.header}>
+        <Image src={icon} alt="saved moa icon" />
+        <h3 className={styles.title}>지난 모아 보관함</h3>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/[year]/saved-moa/[id]/layout.tsx
+++ b/src/app/[year]/saved-moa/[id]/layout.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image";
 import icon from "@/../public/assets/icons/nav_sidebar/saved_moa_icon.svg";
-import styles from "@/styles/selectMoa.module.css";
+import styles from "@/styles/SavedMoa.module.css";
 export default function SavedMoaLayout({ children }) {
   return (
     <div className={styles.layoutContainer}>
       <div className={styles.header}>
-        <Image src={icon} alt="saved moa icon" />
+        <Image src={icon} alt="saved moa icon" width={28} />
         <h3 className={styles.title}>지난 모아 보관함</h3>
       </div>
       {children}

--- a/src/app/[year]/saved-moa/[id]/layout.tsx
+++ b/src/app/[year]/saved-moa/[id]/layout.tsx
@@ -8,6 +8,7 @@ export default function SavedMoaLayout({ children }) {
         <Image src={icon} alt="saved moa icon" width={28} />
         <h3 className={styles.title}>지난 모아 보관함</h3>
       </div>
+
       {children}
     </div>
   );

--- a/src/app/[year]/saved-moa/[id]/page.tsx
+++ b/src/app/[year]/saved-moa/[id]/page.tsx
@@ -25,10 +25,19 @@ export default async function SavedMoaPage() {
       mailBoxDesign: { select: { imageURL: true } },
     },
   });
-  //지난 모아박스가 없는 경우
+  //지난 모아박스가 없는 경우 폴백 화면(추후 수정 예정)
   if (!savedMoaBoxes.length) {
     return (
-      <div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          height: "60vh",
+          justifyContent: "center",
+          opacity: "0.5",
+        }}
+      >
         <Image
           src="/assets/broke_cat.svg"
           alt="no moa"

--- a/src/app/[year]/saved-moa/[id]/page.tsx
+++ b/src/app/[year]/saved-moa/[id]/page.tsx
@@ -1,3 +1,3 @@
-export default function SeasonMoaPage() {
+export default function SavedMoaPage() {
   return <div>Season Moa Page</div>;
 }

--- a/src/app/[year]/saved-moa/[id]/page.tsx
+++ b/src/app/[year]/saved-moa/[id]/page.tsx
@@ -1,3 +1,91 @@
-export default function SavedMoaPage() {
-  return <div>Season Moa Page</div>;
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/app/api/auth/authoptions";
+import { getServerSession } from "next-auth/next";
+import NotFound from "@/app/[year]/(components)/not-found";
+import Image from "next/image";
+import Link from "next/link";
+import { Suspense } from "react";
+import { MoaBox } from "@/types/moabox";
+import styles from "@/styles/SavedMoa.module.css";
+
+export default async function SavedMoaPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || !session?.user) {
+    return NotFound();
+  }
+  //dueDate가 지난 모아 박스만 조회
+  const savedMoaBoxes = await prisma.moaBox.findMany({
+    where: {
+      ownerId: session.user.id,
+      dueDate: {
+        lte: new Date(),
+      },
+    },
+    include: {
+      mailBoxDesign: { select: { imageURL: true } },
+    },
+  });
+  //지난 모아박스가 없는 경우
+  if (!savedMoaBoxes.length) {
+    return (
+      <div>
+        <Image
+          src="/assets/broke_cat.svg"
+          alt="no moa"
+          width={180}
+          height={180}
+        />
+        <p>아직 종료된 모아 박스가 없어요!</p>
+      </div>
+    );
+  }
+
+  //모아 박스 년도별로 그룹
+  const groupedByYear = savedMoaBoxes.reduce((group, moabox) => {
+    //년도 추출(dueDate가 반드시 있다는 전제 하에)
+    const year = new Date(moabox.dueDate).getFullYear();
+    if (!group[year]) {
+      group[year] = [];
+    }
+    //key : 년도, value : 해당년도의 모아 박스
+    //ex : {2023:[23년도 모아박스1, 23년도 모아박스2 ...], 2024:[2024년도 모아박스] ... }
+    group[year].push(moabox);
+    return group;
+  }, {} as Record<number, MoaBox[]>); //값 초기화
+  // console.log(groupedByYear);
+
+  const sortedYears = Object.keys(groupedByYear) //내림차순 정렬
+    .map(Number)
+    .sort((a, b) => b - a);
+  // console.log(sortedYears);
+
+  return (
+    <div className={styles.container}>
+      {sortedYears.map(year => (
+        <section key={year} className={styles.yearSection}>
+          <div className={styles.yearHeader}>
+            <p className={styles.yearTitle}>{year} 모아 보관함</p>
+            {/* <hr className={styles.divideLine} /> */}
+          </div>
+          <div className={styles.moaBoxesWrapper}>
+            {groupedByYear[year].map(moaBox => (
+              <Link
+                href={`/2025/moa/mymoa/${moaBox.id}`}
+                key={moaBox.id}
+                className={styles.moaBoxLink}
+              >
+                <div
+                  className={styles.moaBoxImage}
+                  style={{
+                    backgroundImage: `url(${moaBox.mailBoxDesign.imageURL})`,
+                  }}
+                />
+                <p className={styles.moaBoxTitle}>{moaBox.title}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
 }

--- a/src/styles/SavedMoa.module.css
+++ b/src/styles/SavedMoa.module.css
@@ -1,0 +1,84 @@
+/*레이아웃 쪽*/
+.layoutContainer {
+  padding: 0 40px;
+  height: 100vh;
+  padding-top: 100px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+/*본문*/
+.container {
+  margin-top: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.noMoaContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 40px;
+  text-align: center;
+}
+
+/* .yearSection {
+  margin-bottom: 40px;
+} */
+
+.yearHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.yearTitle {
+  margin: 0;
+  color: var(--color-gray-300);
+}
+
+.divideLine {
+  flex: 1;
+  margin-left: 15px;
+  border: none;
+  border-top: 1px solid var(--color-gray-200);
+}
+
+.moaBoxesWrapper {
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.moaBoxLink {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--color-black);
+}
+
+.moaBoxImage {
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 60px;
+  height: 80px;
+}
+
+.moaBoxTitle {
+  margin: 0;
+  font-size: 14px;
+}

--- a/src/styles/SavedMoa.module.css
+++ b/src/styles/SavedMoa.module.css
@@ -1,8 +1,23 @@
 /*레이아웃 쪽*/
 .layoutContainer {
-  padding: 0 40px;
-  height: 100vh;
-  padding-top: 100px;
+  padding: 100px 40px 20px 40px;
+  overflow: auto;
+}
+
+/*스크롤 넓이 설정*/
+.layoutContainer::-webkit-scrollbar {
+  width: 6px;
+}
+
+/* 스크롤바 막대 설정*/
+.layoutContainer::-webkit-scrollbar-thumb {
+  background-color: rgba(206, 206, 206, 0.541);
+  border-radius: 10px;
+}
+
+/* 스크롤바 뒷 배경 설정*/
+.layoutContainer::-webkit-scrollbar-track {
+  background-color: rgba(0, 0, 0, 0);
 }
 
 .header {
@@ -19,23 +34,20 @@
 
 /*본문*/
 .container {
-  margin-top: 40px;
+  margin-top: 44px;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 50px;
+  overflow-y: auto;
 }
 
 .noMoaContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 40px;
+  margin-top: 44px;
   text-align: center;
 }
-
-/* .yearSection {
-  margin-bottom: 40px;
-} */
 
 .yearHeader {
   display: flex;
@@ -56,9 +68,9 @@
 }
 
 .moaBoxesWrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 100px));
   gap: 32px;
-  flex-wrap: wrap;
 }
 
 .moaBoxLink {
@@ -74,11 +86,21 @@
   background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
-  width: 60px;
-  height: 80px;
+  width: 80%;
+  aspect-ratio: 1 / 1;
+  transition: 0.2s ease;
+}
+
+.moaBoxImage:hover {
+  scale: 1.05;
 }
 
 .moaBoxTitle {
   margin: 0;
   font-size: 14px;
+  text-align: center;
+  white-space: nowrap;
+  max-width: 100px;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }

--- a/src/types/moabox.ts
+++ b/src/types/moabox.ts
@@ -13,7 +13,7 @@ export type MoaBox = {
   updatedAt: Date;
   backgroundDesignId: number;
   mailBoxDesignId: number;
-  backgroundDesign: {
+  backgroundDesign?: {
     imageURL: string;
   };
   mailBoxDesign: {


### PR DESCRIPTION
## 📌제목 : Feat : Moa-138 Add saved-moa page

### ➡️PR 방향

- [x] 초기(첫 푸시) → 지난 모아 보관함(saved-moa) 페이지가 추가 됐어요
- [x] 수정 → `moaBox의 만료 여부 확인 로직`이 추가 됐어요(만료 여부에 따라 `select-moa`에 표시,
                   `mymoa`에서 버튼 스타일 변경)
                → `SideBar.tsx`에서 아이템 순서(마이페이지 <-> 친구 목록) 순서가 변경됐어요
                → `/mymoa` 하위 컴포넌트에 짜잘한 수정이 있어요
                    (`HandleAddFriend` 비즈니스 컴포넌트에서 사용된 `useCallBack dependency`에 `Alert 
                    함수 추가`, `LetterModa`l에 `Spotify iframe`에 `border-radius` 추가)
                → `Button.tsx` 컴포넌트의 `blocked css` 색상이 변경 됐어요
                →  /types/moaBox에서 interface MoaBox의 backgroundImageUrl 속성이 옵셔널로 변경됐어요

---

### 📝내용


**추가**
(영상에 표시된 이미지들은 임시입니다)
![제목 없는 동영상 - Clipchamp로 제작 (2)](https://github.com/user-attachments/assets/606dd34b-51b1-4c54-95e6-e6fc42f86bec)

- /saved-moa 페이지가 추가됐습니다!(css 파일 포함)

**수정**
*select-moa*
- 소유한 모든 모아 박스를 출력하던 기존 로직에 '만료되지 않은' 조건이 추가 됐습니다(gte)

*mymoa*
- 모아 박스 만료 여부를 `isExpired`값에 저장하여, css , 비즈니스 로직에 변화를 줍니다

*SideBar.tsx*
- 친구 목록, 마이 페이지 순서를 바꿨습니다



---

#### ⛓️연결된 이슈 :

closes MOA-138
