### PR TITLE
feat: create moa step 3, select modal friend state data edit

### DIFF
--- a/src/app/[year]/(create)/(components)/SelectModal.tsx
+++ b/src/app/[year]/(create)/(components)/SelectModal.tsx
@@ -4,7 +4,8 @@ import { FiPlusCircle } from "react-icons/fi";
 import { FaRegCircleCheck } from "react-icons/fa6";
 import { useEffect, useState } from "react";
 import { IoMdClose } from "react-icons/io";
-import type { MemberType } from "@/types/createMoa";  // db 데이터 저장 (임시) 
+import type { ServerType } from "@/types/createMoa";
+
 
 const List = ({
     check, state, name
@@ -39,7 +40,7 @@ export default function SelectModal({
     onMemberChange: (data: string[]) => void,
     check: (data: string) => void,
     removeMember: (data: string) => void,
-    memberValue: MemberType[],
+    memberValue: ServerType[],
     friendData: string[],
 }) {
     const [ischeck, setisCheck] = useState(false);
@@ -59,8 +60,8 @@ export default function SelectModal({
             <div className={styles.selectModal_main}>
                 <div className={styles.input}>
                     {ischeck ?
-                        <>{friendData.map((name) => (
-                            <p key={name}>
+                        <>{friendData.map((name, id) => (
+                            <p key={id}>
                                 {name}
                                 <IoMdClose
                                     className={styles.close_icon}
@@ -73,16 +74,17 @@ export default function SelectModal({
                 </div>
                 <p className={styles.middle_p}>초대 가능한 친구</p>
                 <div className={styles.middle}>
-
-                    {memberValue.map((name) => (
-                        <div key={name.name} className={styles.middle_list}>
+                    {memberValue.length > 0 ? memberValue.map((name, id) => (
+                        <div key={id} className={styles.middle_list}>
                             <List
                                 check={check}
                                 state={name.selected}
                                 name={name.name}>
                             </List>
-                        </div>
-                    ))}
+                        </div>))
+                        : <div className={styles.friend_list}>
+                            <p>친구 목록이 비어있습니다</p>
+                        </div>}
                 </div>
                 <div className={styles.bottom_tag}>
                     {ischeck ?

--- a/src/app/[year]/(create)/(components)/SelectModal.tsx
+++ b/src/app/[year]/(create)/(components)/SelectModal.tsx
@@ -4,6 +4,7 @@ import { FiPlusCircle } from "react-icons/fi";
 import { FaRegCircleCheck } from "react-icons/fa6";
 import { useEffect, useState } from "react";
 import { IoMdClose } from "react-icons/io";
+import type { MemberType } from "@/types/createMoa";  // db 데이터 저장 (임시) 
 
 const List = ({
     check, state, name
@@ -31,73 +32,40 @@ const List = ({
     )
 }
 
-type MemberType = {
-    name: string;
-    selected: boolean;
-};
-
 export default function SelectModal({
-    onClose, onMemberChange,
+    onClose, onMemberChange, check, removeMember, memberValue, friendData,
 }: {
     onClose: () => void,
     onMemberChange: (data: string[]) => void,
+    check: (data: string) => void,
+    removeMember: (data: string) => void,
+    memberValue: MemberType[],
+    friendData: string[],
 }) {
-
     const [ischeck, setisCheck] = useState(false);
-    const [member, setMember] = useState<string[]>([]);
 
-    //임시데이터
-    const [friend, setFriend] = useState<MemberType[]>([
-        { name: "머가문", selected: false },
-        { name: "멈가문", selected: false },
-        { name: "현가문", selected: false },
-        { name: "이가문", selected: false },
-        { name: "최가문", selected: false },
-        { name: "고가문", selected: false },
-    ]);
-
+    // input tag 상태 체크 
     useEffect(() => {
-        const booleanCheck = friend.filter((friend) => friend.selected).length;
+        const booleanCheck = memberValue.filter((friend) => friend.selected).length;
         if (booleanCheck === 0) {
             setisCheck(false);
         } else {
             setisCheck(true);
         }
-    }, [friend]);
-
-    useEffect(() => {
-        const onDateChange = friend.filter((friend) => friend.selected)
-            .map((friend) => friend.name);
-        setMember(onDateChange);
-    }, [friend]);
-
-    // ["머가문", "멈가문", "현가문"] 의 boolean 값 상태체크
-    const check = (name_: string) =>
-        setFriend((prev) =>
-            prev.map((friend) =>
-                friend.name === name_
-                    ? { ...friend, selected: !friend.selected }
-                    : friend
-            )
-        );
-
-    //친구선택 목록에서 x버튼으로 이름 빼기
-    const removeMember = (remove: string) => {
-        setMember(prevMember => prevMember.filter((memberName, idx) => memberName !== remove));
-    };
+    }, [memberValue]);
 
     return (
         <div>
             <div className={styles.selectModal_main}>
                 <div className={styles.input}>
                     {ischeck ?
-                        <>{member.map((member, id) => (
-                            <p key={id}>
-                                {member}
+                        <>{friendData.map((name) => (
+                            <p key={name}>
+                                {name}
                                 <IoMdClose
                                     className={styles.close_icon}
                                     size="20px"
-                                    onClick={() => removeMember(member)} />
+                                    onClick={() => removeMember(name)} />
                             </p>
                         ))}</>
                         :
@@ -106,7 +74,7 @@ export default function SelectModal({
                 <p className={styles.middle_p}>초대 가능한 친구</p>
                 <div className={styles.middle}>
 
-                    {friend.map((name) => (
+                    {memberValue.map((name) => (
                         <div key={name.name} className={styles.middle_list}>
                             <List
                                 check={check}
@@ -120,7 +88,7 @@ export default function SelectModal({
                     {ischeck ?
                         <div
                             className={styles.selectModal_select_button}
-                            onClick={() => { onClose(); onMemberChange(member); }}>
+                            onClick={() => { onClose(); onMemberChange(friendData); }}>
                             <Button label="선택완료" size="modalBtn" color="black"></Button>
                         </div> : ''}
                 </div>

--- a/src/app/[year]/(create)/create-moa/step3.tsx
+++ b/src/app/[year]/(create)/create-moa/step3.tsx
@@ -9,7 +9,7 @@ import styles from "@/styles/createMoa.module.css";
 import type { NextStepProps } from "@/types/createMoa";
 import SelectModal from "../(components)/SelectModal";
 import Modal from "../../(components)/common/Modal";
-
+import type { MemberType } from "@/types/createMoa";  // db 데이터 저장 (임시) 
 
 export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
   const today = dayjs(new Date()).format("YYYY-MM-DD");
@@ -24,13 +24,63 @@ export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
   const [openSelect, setOpenSelect] = useState(false);
   const [member, setMember] = useState<string[]>([]);
 
-  const submitHandler = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    console.log(e.currentTarget.moa_name.value)
-    console.log(e.currentTarget.start_day.value)
-    console.log(e.currentTarget.end_day.value)
-    console.log(e.currentTarget.group.value)
+
+
+  /* ----------------- /     modal.tsx     /----------------- */
+  /* ---------------------------------------------------------*/
+
+  // 모달 컴포넌트 닫기 
+  const onClose = () => {
+    setOpenSelect(false)
   };
+
+  /* ----------------- /     select modal.tsx     /----------------- */
+  /* --------------------------------------------------------------- */
+
+  // db 데이터 저장 (임시)
+  const [friend, setFriend] = useState<MemberType[]>([
+    { name: "머가문", selected: false },
+    { name: "멈가문", selected: false },
+    { name: "현가문", selected: false },
+    { name: "이가문", selected: false },
+    { name: "최가문", selected: false },
+    { name: "고가문", selected: false },
+  ]);
+
+  // select modal input tag 실시간 반영
+  const [friendData, setMemberData] = useState<string[]>([]);
+
+  // select modal boolean 값 데이터 처리
+  const check = (name_: string) => {
+    setFriend((prev) =>
+      prev.map((friend) =>
+        friend.name === name_
+          ? { ...friend, selected: !friend.selected }
+          : friend
+      ));
+    setMemberData(friend.filter((friend) => friend.selected).map(friend => friend.name));
+  }
+
+  //select modal 선택된 친구 x버튼으로 빼기
+  const removeMember = (remove: string) => {
+    setFriend((prev) =>
+      prev.map((friend) =>
+        friend.name === remove
+          ? { ...friend, selected: false }
+          : friend
+      ));
+  };
+
+  // select modal boolean 데이터 변경때마다 input창에 실시간 데이터 반영
+  useEffect(() => {
+    const onDateChange = friend.filter((friend) => friend.selected).map(friend => friend.name);
+    setMemberData(onDateChange);
+  }, [friend]);
+
+
+  /* ----------------- /     calendar.tsx     /----------------- */
+  /* ----------------------------------------------------------- */
+
 
   // calendar.tsx 콜백 함수 : 초기 세팅 날짜를 현재 날짜로
   const onStartDayHandler = (data: string) => {
@@ -45,8 +95,17 @@ export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
     console.log(data)
   };
 
-  const groupHandler = () => {
-    setIsOpen(!isOpen);
+
+  /* ----------------- /     step3.tsx     /----------------- */
+  /* -------------------------------------------------------- */
+
+  // form tag onSubmit data 
+  const submitHandler = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log(e.currentTarget.moa_name.value)
+    console.log(e.currentTarget.start_day.value)
+    console.log(e.currentTarget.end_day.value)
+    console.log(e.currentTarget.group.value)
   };
 
   //input에 데이터 입력이 되어있을때 input border색 변경
@@ -54,12 +113,13 @@ export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
     console.log("입력완")
     setColor(!!e.currentTarget.value)
   };
+
   //input border색 변경 - 모아 그룹 설정 
-  useEffect(()=>{
-     if(member.length > 0){
+  useEffect(() => {
+    if (member.length > 0) {
       setMemberColor(!!member)
     }
-  },[member]);
+  }, [member]);
 
   //select modal.tsx에서 받아온 이름 적용
   const onDateChange = (data: string[]) => {
@@ -67,9 +127,9 @@ export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
     console.log(`${"setMember 확인 : " + member}`)
   };
 
-  //모달 컴포넌트 닫기 
-  const onClose = () => {
-    setOpenSelect(false)
+  // 모아 그룹 설정 disabled input 태그 활성화 
+  const groupHandler = () => {
+    setIsOpen(!isOpen);
   };
 
   return (
@@ -80,7 +140,11 @@ export default function CreateMoaStep3<NextStepProps>({ nextStep }) {
         content={
           <SelectModal
             onClose={() => setOpenSelect(false)}
-            onMemberChange={onDateChange} />
+            onMemberChange={onDateChange}
+            memberValue={friend}
+            check={check}
+            removeMember={removeMember}
+            friendData={friendData} />
         }>
       </Modal>
       <div className={styles.step3_container}>

--- a/src/styles/SelectModal.module.css
+++ b/src/styles/SelectModal.module.css
@@ -210,3 +210,8 @@
 .bold {
     font-weight: 700;
 }
+
+.friend_list {
+    text-align: center;
+    color: var(--color-gray-300);
+}

--- a/src/styles/modal.module.css
+++ b/src/styles/modal.module.css
@@ -1,4 +1,4 @@
-/*모달 공통통*/
+/*모달 공통*/
 .X_btn {
   width: 14px;
   height: 14px;
@@ -9,8 +9,6 @@
 }
 
 .action_btn_wrapper {
-  left: 0;
-  width: 100%;
   position: absolute;
   bottom: 25px;
   display: flex;

--- a/src/types/createMoa.ts
+++ b/src/types/createMoa.ts
@@ -11,3 +11,9 @@ export interface NextStepProps {
     nextStep: () => void;
     goSelectMoa?: () => void;
 }
+
+// db 데이터 저장 임시 
+export type MemberType = {
+    name: string;
+    selected: boolean;
+};

--- a/src/types/createMoa.ts
+++ b/src/types/createMoa.ts
@@ -1,6 +1,6 @@
 export interface DotNavProps {
-  colors: string[]; // 색 배열
-  onClick: (index: number) => void; // 클릭 이벤트
+    colors: string[]; // 색 배열
+    onClick: (index: number) => void; // 클릭 이벤트
 }
 
 export interface ToggleLabelProps {
@@ -12,8 +12,11 @@ export interface NextStepProps {
     goSelectMoa?: () => void;
 }
 
-// db 데이터 저장 임시 
-export type MemberType = {
+export type ServerType = {
+    id: string;
     name: string;
-    selected: boolean;
+    nickname: string;
+    profileImage: string;
+    moaBoxOngoing: boolean;
+    selected?: boolean;
 };


### PR DESCRIPTION
## 📌제목 : create moa step 3, select modal friend state data edit, db data fetch

### ➡️PR 방향

- [ ] 초기(첫 푸시) → 첫 푸시 내용 설명 요망
- [x] 수정 → 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 버그 → 버그 스크린 샷 첨부 요망
- [ ] 요청 → 요청 부분 설명 요망

### 📝내용

- modal.tsx 버튼 위치 수정
- selectModal.tsx 로직들을 step3.tsx로 이동
: 데이터 선택 후에 수정을 위해 재진입했을때 기존에 입력해둔 데이터 반영 (step3.tsx <-> selectModal.tsx)
- select modal에서 friend list와 input tag 데이터 간 선택과 해제시에 따로 작동하던 state 데이터 통일
https://github.com/user-attachments/assets/fa125177-843c-4d3b-851b-066eaffeb369
- db 데이터 반영



---

#### ⛓️연결된 이슈 :

closes MOA-168
