### PR TITLE
feat: Add background image to BackgroundLayout.tsx, edit saved-moa, sent-letter page scroll

### DIFF
--- a/src/app/[year]/(components)/common/BackgroundLayout.tsx
+++ b/src/app/[year]/(components)/common/BackgroundLayout.tsx
@@ -1,4 +1,5 @@
 import styles from "../../../../styles/backgroundLayout.module.css";
+import backgroundImg from "public/assets/moamoa_paper_texture.jpg";
 export default function BackgroundLayout({
   children,
 }: {
@@ -6,7 +7,16 @@ export default function BackgroundLayout({
 }) {
   return (
     <>
-      <div className={styles.container}>{children}</div>
+      <div
+        style={{
+          backgroundImage: `url(${backgroundImg.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+        className={styles.container}
+      >
+        {children}
+      </div>
     </>
   );
 }

--- a/src/app/[year]/saved-moa/[id]/layout.tsx
+++ b/src/app/[year]/saved-moa/[id]/layout.tsx
@@ -8,7 +8,6 @@ export default function SavedMoaLayout({ children }) {
         <Image src={icon} alt="saved moa icon" width={28} />
         <h3 className={styles.title}>지난 모아 보관함</h3>
       </div>
-
       {children}
     </div>
   );

--- a/src/app/[year]/saved-moa/[id]/page.tsx
+++ b/src/app/[year]/saved-moa/[id]/page.tsx
@@ -28,18 +28,7 @@ export default async function SavedMoaPage() {
   //지난 모아박스가 없는 경우 폴백 화면(추후 수정 예정)
   if (!savedMoaBoxes.length) {
     return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          height: "60vh",
-          justifyContent: "center",
-          opacity: "0.2",
-          gap: "12px",
-          paddingTop: "5vh",
-        }}
-      >
+      <div className={styles.noMoaBoxContainer}>
         <Image src={moaCatImg} alt="no moa" width={280} />
         <p>아직 종료된 모아 박스가 없어요!</p>
       </div>
@@ -69,7 +58,10 @@ export default async function SavedMoaPage() {
     <div className={styles.container}>
       {/* 년도별 카테고리 */}
       {sortedYears.map(year => (
-        <section key={year} className={styles.yearSection}>
+        <section
+          key={year}
+          className={`${styles.yearSection} ${styles.snapGroup}`}
+        >
           <div className={styles.yearHeader}>
             <p className={styles.yearTitle}>{year} 모아 보관함</p>
             {/* <hr className={styles.divideLine} /> */}

--- a/src/app/[year]/sent-letter/[id]/page.tsx
+++ b/src/app/[year]/sent-letter/[id]/page.tsx
@@ -16,18 +16,7 @@ export default async function SentLetterPage() {
 
   if (!sentLetters.length) {
     return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          height: "60vh",
-          justifyContent: "center",
-          opacity: "0.2",
-          gap: "12px",
-          paddingTop: "5vh",
-        }}
-      >
+      <div className={styles.noMoaBoxContainer}>
         <Image src={moaCatImg} alt="no moa" width={280} />
         <p style={{ textAlign: "center" }}>
           작성한 편지가 없습니다.
@@ -44,7 +33,7 @@ export default async function SentLetterPage() {
         <OpenSentLetter letter={letter} key={letter.id}>
           {/* 편지 카드 */}
           <div
-            className={styles.card}
+            className={`${styles.card} ${styles.snapGroup}`}
             style={{
               backgroundImage: `url(${letter.letterPaperDesign.imageURL})`,
             }}

--- a/src/styles/SavedMoa.module.css
+++ b/src/styles/SavedMoa.module.css
@@ -1,23 +1,6 @@
 /*레이아웃 쪽*/
 .layoutContainer {
   padding: 100px 40px 20px 40px;
-  overflow: auto;
-}
-
-/*스크롤 넓이 설정*/
-.layoutContainer::-webkit-scrollbar {
-  width: 6px;
-}
-
-/* 스크롤바 막대 설정*/
-.layoutContainer::-webkit-scrollbar-thumb {
-  background-color: rgba(206, 206, 206, 0.541);
-  border-radius: 10px;
-}
-
-/* 스크롤바 뒷 배경 설정*/
-.layoutContainer::-webkit-scrollbar-track {
-  background-color: rgba(0, 0, 0, 0);
 }
 
 .header {
@@ -32,21 +15,43 @@
   font-weight: bold;
 }
 
-/*본문*/
-.container {
-  margin-top: 44px;
-  display: flex;
-  flex-direction: column;
-  gap: 50px;
-  overflow-y: auto;
-}
-
-.noMoaContainer {
+/*데이터 없을 때 화면*/
+.noMoaBoxContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 60vh;
+  justify-content: center;
+  opacity: 0.2;
+  gap: 12px;
+  padding-top: 5vh;
+}
+
+/*본문*/
+.container {
+  height: 68vh;
+  overflow-y: auto;
   margin-top: 44px;
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 52px;
+  /*스크롤바 스냅 포인트 적용하기*/
+  scroll-snap-type: y mandatory;
+  padding-bottom: 50px;
+}
+
+/* 스크롤바 투명 처리 */
+.container::-webkit-scrollbar {
+  width: 2px;
+}
+.container::-webkit-scrollbar-thumb,
+.container::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+/*자식 요소를 스냅 포인트로 지정 */
+.snapGroup {
+  scroll-snap-align: start;
 }
 
 .yearHeader {

--- a/src/styles/SentLetter.module.css
+++ b/src/styles/SentLetter.module.css
@@ -1,22 +1,7 @@
 /*layout.tsx 영역*/
 .layoutContainer {
   padding: 100px 40px 20px 40px;
-  overflow: auto;
-}
-/*스크롤 넓이 설정*/
-.layoutContainer::-webkit-scrollbar {
-  width: 6px;
-}
-
-/* 스크롤바 막대 설정*/
-.layoutContainer::-webkit-scrollbar-thumb {
-  background-color: rgba(206, 206, 206, 0.541);
-  border-radius: 10px;
-}
-
-/* 스크롤바 뒷 배경 설정*/
-.layoutContainer::-webkit-scrollbar-track {
-  background-color: rgba(0, 0, 0, 0);
+  overflow: hidden;
 }
 
 .header {
@@ -32,26 +17,45 @@
 }
 
 /*page.tsx 영역*/
-/* 페이지가 비어있을 때 보여줄 화면 */
-.emptyWrapper {
+/*데이터 없을 때 화면*/
+.noMoaBoxContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
   height: 60vh;
   justify-content: center;
-  opacity: 0.5;
+  opacity: 0.2;
+  gap: 12px;
+  padding-top: 5vh;
 }
-.emptyText {
-  text-align: center;
-}
+
 /* 페이지 내부 */
 .container {
+  height: 74vh;
   margin-top: 44px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 24px;
   overflow-y: auto;
+  /*스크롤바 스냅 포인트 적용하기*/
+  scroll-snap-type: y mandatory;
+  padding: 0 10px 50px 10px;
 }
+
+/*자식 요소를 스냅 포인트로 지정 */
+.snapGroup {
+  scroll-snap-align: start;
+}
+
+/*스크롤 투명 설정*/
+.container::-webkit-scrollbar {
+  width: 2px;
+}
+.container::-webkit-scrollbar-thumb,
+.container::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
 /* 카드  */
 .card {
   background-size: cover;
@@ -63,9 +67,7 @@
 }
 /* 카드 내부 */
 .cardContent {
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
+  overflow-y: hidden;
   height: 220px;
 }
 /* 카드 수신인 */

--- a/src/styles/selectMoa.module.css
+++ b/src/styles/selectMoa.module.css
@@ -1,7 +1,6 @@
 /*select-moa/layout.tsx css*/
 .layoutContainer {
   padding: 0 40px;
-  background-color: var(--color-gray-300);
   height: 100vh;
   padding-top: 12vh;
 }


### PR DESCRIPTION
## 📌제목 : feat: Add background image to BackgroundLayout.tsx, edit saved-moa, sent-letter page scroll

### ➡️PR 방향

- [ ] 초기(첫 푸시) → 첫 푸시 내용 설명 요망
- [x] 수정 → 원본, 바뀐 부분 첨부, 설명 요망

---

### 📝내용

**BackgroundLayout.tsx**
- 종이 질감의 png파일이 ` backgroundImage` 로 추가됐습니다

**saved-moa, sent-letter 페이지**
- 페이지 타이틀까지 같이 스크롤 되던 기존의 방식을 `컨텐츠 영역에만 스크롤` 되게 변경
- `css scroll-snap` 을 통해 스크롤 시 자식 요소를 자동으로 인식하도록 수정
- 기존 inline으로 작성 됐던 fallback 화면 css를 module.css 파일로 이동

---

#### ⛓️연결된 이슈 :

closes
