### PR TITLE
design: mypage alert modify

### DIFF
--- a/src/app/[year]/mypage/page.tsx
+++ b/src/app/[year]/mypage/page.tsx
@@ -4,7 +4,7 @@ import { signIn, signOut, useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ToastContainer, toast } from "react-toastify";
-import { AlertProvider } from "../(components)/common/Alert";
+import { useAlertContext } from "@/contexts/AlertContext";
 import Button from "@/app/[year]/(components)/common/Button";
 import Image from "next/image";
 import moa_cat from "../../../../public/assets/icons/notification/notification_moa_cat.svg";
@@ -16,12 +16,16 @@ import jumparrow from "../../../../public/assets/icons/jump-arrow.svg";
 import styles from "@/styles/mypage.module.css";
 
 export default function MyPage() {
-  // 사용자 세션 정보 가져오기
+  const { showAlert, showConfirmModal } = useAlertContext();
   const { data: session, status } = useSession();
   const router = useRouter();
   const isLoggedIn = !!session?.user;
+
   const [spotifyConnected, setSpotifyConnected] = useState(false);
   const [nickname, setNickname] = useState(session?.user?.name ?? "Guest");
+  const [editedNickname, setEditedNickname] = useState(
+    session?.user?.name ?? "Guest"
+  );
   const [profileImage, setProfileImage] = useState(
     session?.user?.image ?? moa_cat
   );
@@ -66,133 +70,153 @@ export default function MyPage() {
   };
 
   // 로그아웃 처리 및 리디렉션
-  const handleLogout = async () => {
-    try {
-      await signOut({ callbackUrl: "/auth/login", redirect: true });
-    } catch (error) {
-      console.error("Logout failed:", error);
-      toast.error("로그아웃 실패");
-    }
+  const handleLogout = () => {
+    showConfirmModal({
+      icon: "질문",
+      confirmMessage: "로그아웃",
+      message: "다시 로그인하려면 비밀번호가 필요해요.",
+      onConfirm: async () => {
+        try {
+          await signOut({ redirect: false });
+          // toast.success("로그아웃 되었습니다.");
+          router.push("/auth/login");
+        } catch (error) {
+          console.error("Logout failed:", error);
+          toast.error("로그아웃 실패");
+        }
+      },
+    });
   };
 
   // 회원탈퇴
   const handleDeleteAccount = async () => {
-    try {
-      const res = await fetch(`/api/user/delete`, { method: "DELETE" });
-      const data = await res.json();
+    showConfirmModal({
+      icon: "경고",
+      confirmMessage: "회원탈퇴",
+      message: "회원탈퇴 시 모든 정보가 삭제돼요!",
+      onConfirm: async () => {
+        try {
+          const res = await fetch(`/api/user/delete`, { method: "DELETE" });
+          const data = await res.json();
 
-      if (res.ok) {
-        await signOut({ callbackUrl: "/auth/login" });
-      } else {
-        toast.error(data.error || "회원탈퇴 실패");
-      }
-    } catch (error) {
-      console.error("회원탈퇴 실패:", error);
-      toast.error("회원탈퇴 실패");
-    }
+          if (res.ok) {
+            await signOut({ callbackUrl: "/auth/login" });
+          } else {
+            toast.error(data.error || "회원탈퇴 실패");
+          }
+        } catch (error) {
+          console.error("회원탈퇴 실패:", error);
+          toast.error("회원탈퇴 실패");
+        }
+      },
+    });
+  };
+
+  // 닉네임 변경
+  const handleNicknameSave = async () => {
+    setNickname(editedNickname);
+    toast.success("닉네임 변경 완료!");
+    // await fetch()
   };
 
   return (
-    <AlertProvider>
-      {({ showConfirmModal }) => (
-        <div className={styles.allContainer}>
-          <div className={styles.container}>
-            {/* 프로필 섹션 */}
-            <div className={styles.profileSection}>
-              <div className={styles.profileImage}>
-                <Image
-                  src={profileImage}
-                  alt="profile Image"
-                  width={125}
-                  height={125}
-                  className={styles.noprofileImage}
-                />
-              </div>
-              <div className={styles.userinfo}>
-                <div className={styles.userName}>{nickname}</div>
-                <div className={styles.loginWith}>
+    <div className={styles.allContainer}>
+      <div className={styles.container}>
+        {/* 프로필 섹션 */}
+        <div className={styles.profileSection}>
+          <div className={styles.profileImage}>
+            <Image
+              src={profileImage}
+              alt="profile Image"
+              width={125}
+              height={125}
+              className={styles.noprofileImage}
+            />
+          </div>
+          <div className={styles.userinfo}>
+            <div className={styles.userName}>{nickname}</div>
+            <div className={styles.loginWith}>
+              <Image
+                src={kakao}
+                alt="connect icon"
+                width={14}
+                height={14}
+                style={{ paddingRight: 6 }}
+              />
+              {isLoggedIn ? "연동 로그인 중" : "로그인 정보 없음"}
+            </div>
+            <div className={styles.spotify}>
+              <Image
+                src={spotify}
+                alt="connect icon"
+                width={14}
+                height={14}
+                style={{ paddingRight: 6 }}
+              />
+              Spotify
+              {spotifyConnected ? " 연결중" : " 연결하기"}
+              {!spotifyConnected && (
+                <div className={styles.spotify_signout}>
                   <Image
-                    src={naver}
+                    src={jumparrow}
                     alt="connect icon"
-                    width={14}
-                    height={14}
-                    style={{ paddingRight: 6 }}
+                    width={10}
+                    height={10}
+                    style={{ paddingLeft: 7, cursor: "pointer" }}
+                    onClick={handleConnectSpotify}
                   />
-                  {isLoggedIn ? "연동 로그인 중" : "로그인 정보 없음"}
                 </div>
-                <div className={styles.spotify}>
-                  <Image
-                    src={spotify}
-                    alt="connect icon"
-                    width={14}
-                    height={14}
-                    style={{ paddingRight: 6 }}
-                  />
-                  Spotify
-                  {spotifyConnected ? " 연결중" : " 연결하기"}
-                  {!spotifyConnected && (
-                    <div className={styles.spotify_signout}>
-                      <Image
-                        src={jumparrow}
-                        alt="connect icon"
-                        width={10}
-                        height={10}
-                        style={{ paddingLeft: 7, cursor: "pointer" }}
-                        onClick={handleConnectSpotify}
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
+              )}
             </div>
+          </div>
+        </div>
 
-            {/* 닉네임 & 이메일 폼 섹션 */}
-            <div className={styles.formSection}>
-              <div className={styles.formNickname}>
-                <label htmlFor="nickname">닉네임</label>
-                <input type="text" id="nickname" value={nickname} readOnly />
-              </div>
-
-              <div className={styles.formEmail}>
-                <label htmlFor="email">이메일</label>
-                <input
-                  type="email"
-                  value={session?.user?.email ?? "abc@naver.com"}
-                  readOnly
-                />
-              </div>
-            </div>
-
-            {/* 로그아웃 & 회원탈퇴 버튼 섹션 */}
-            <div className={styles.actions}>
-              <button onClick={handleLogout} className={styles.logout}>
-                로그아웃
-              </button>
-              <button
-                className={styles.delete}
-                onClick={() =>
-                  showConfirmModal({
-                    message: "정말 회원탈퇴를 하시겠습니까?",
-                    confirmMessage: "회원탈퇴 확인",
-                    onConfirm: handleDeleteAccount,
-                  })
-                }
-              >
-                회원 탈퇴
-              </button>
-            </div>
-
-            <Button label="저장하기" size="long" color="black" />
+        {/* 닉네임 & 이메일 폼 섹션 */}
+        <div className={styles.formSection}>
+          <div className={styles.formNickname}>
+            <label htmlFor="nickname">닉네임</label>
+            <input
+              type="text"
+              id="nickname"
+              value={editedNickname}
+              onChange={(e) => setEditedNickname(e.target.value)}
+            />
           </div>
 
-          {/* 토스트 메시지 */}
-          <ToastContainer
-            position="bottom-center"
-            autoClose={2000}
-            theme="colored"
-          />
+          <div className={styles.formEmail}>
+            <label htmlFor="email">이메일</label>
+            <input
+              type="email"
+              value={session?.user?.email ?? "abc@naver.com"}
+              readOnly
+            />
+          </div>
         </div>
-      )}
-    </AlertProvider>
+
+        {/* 로그아웃 & 회원탈퇴 버튼 섹션 */}
+        <div className={styles.actions}>
+          <button onClick={handleLogout} className={styles.logout}>
+            로그아웃
+          </button>
+          <button onClick={handleDeleteAccount} className={styles.delete}>
+            회원 탈퇴
+          </button>
+        </div>
+
+        <Button
+          label="저장하기"
+          size="long"
+          color="black"
+          onClick={handleNicknameSave}
+        />
+      </div>
+
+      {/* 토스트 메시지 */}
+      <ToastContainer
+        position="bottom-center"
+        autoClose={2000}
+        theme="colored"
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## 📌 design: mypage alert modify

### ➡️PR 방향

- [ ] 초기(첫 푸시) → 첫 푸시 내용 설명 요망
- [x] 수정 → 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 버그 → 버그 스크린 샷 첨부 요망
- [ ] 요청 → 요청 부분 설명 요망

### 📝내용

**1. AlertProvider → useAlertContext 변경**
- alert의 전체적인 디자인 변화.

**2. 닉네임 편집 기능 추가**
- readonly로 출력만 하던 구조 → `editedNickname` 상태를 도입하여 수정 가능하게 변경.
- 저장 버튼 클릭 시 `handleNicknameSave()` 실행, 변경된 닉네임 로컬 반영 및 toast 알림 표시.

**3. modal message 일부수정**
- `로그아웃`, '회원탈퇴' 사용자의 의사 확인 강화.

**4. ❗️기타 고려사항**
- 닉네임 변경 시, 실제 DB 저장을 위한 로직 필요
- 로그인 연동 정보 아이콘 교체 필요 (네이버로 로그인 했을 시, `naver` 아이콘으로 변경)

---

#### ⛓️연결된 이슈 :

closes
