### PR TITLE
Modify UI

### DIFF
--- a/src/app/(lending-sections)/HomeSection.tsx
+++ b/src/app/(lending-sections)/HomeSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import Image from "next/image";
 import styles from "@/styles/HomeSection.module.css";
 import Hlighter from "./hlighter";

--- a/src/app/(lending-sections)/HomeSection.tsx
+++ b/src/app/(lending-sections)/HomeSection.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import Image from "next/image";
 import styles from "@/styles/HomeSection.module.css";
 import Hlighter from "./hlighter";
+import { useMediaQuery } from "react-responsive";
+import { redirect } from "next/navigation";
+import { useSession } from 'next-auth/react';
+
 
 interface HomeSectionProps {
   onClickNext?: () => void;
 }
 
 export default function HomeSection({ onClickNext }: HomeSectionProps) {
+  const isMobile = useMediaQuery({ maxWidth: 600 });
+  const { data: session, status } = useSession();
+  const handleJoinClick = () => {
+    if (status === 'unauthenticated') return (redirect("/auth/login"))
+    else if (status === 'authenticated') return (redirect("/[year]/create-moa"))
+  };
+
+  if (isMobile && status === 'unauthenticated') return (redirect("/auth/login"))
+  else if (isMobile && status === 'authenticated') return (redirect("/[year]/moa/select-moa"))
+
   return (
     <section className={styles.homeSection}>
       {/* 왼쪽 텍스트 */}
@@ -25,7 +39,7 @@ export default function HomeSection({ onClickNext }: HomeSectionProps) {
               모두와 함께 추억하고 싶은 순간들을 담아줄 MOA BOX를 내 취향대로 꾸미고 서로에게 편지를 건네보세요!`}
             keyword="MOA BOX" />
         </div>
-        <button className={styles.createButton}>만들기</button>
+        <button className={styles.createButton} onClick={handleJoinClick}>만들기</button>
       </div>
 
       {/* 오른쪽 이미지 영역 */}

--- a/src/app/[year]/(create)/create-letter/[id]/page.tsx
+++ b/src/app/[year]/(create)/create-letter/[id]/page.tsx
@@ -34,9 +34,9 @@ export default function CreateLetterStep() {
   const renderDot = () => {
     if (step >= 6) return null;
 
-    const colors = Array(5).fill("gray");
+    const colors = Array(6).fill("gray");
     const activeIndex = step - 1;
-    if (activeIndex >= 0 && activeIndex < 5) {
+    if (activeIndex >= 0 && activeIndex < 6) {
       colors[activeIndex] = "black"; // 현재 step을 검정으로 표시
     }
 

--- a/src/app/[year]/(create)/create-letter/[id]/step5.tsx
+++ b/src/app/[year]/(create)/create-letter/[id]/step5.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import type { createdLetter } from "@/types/createLetter";
 import Button from "../../../(components)/common/Button";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 interface Props {
   letterContentRef: React.MutableRefObject<createdLetter>;
@@ -13,6 +14,7 @@ export default function CreateLetterStep5({
   nextStep,
 }: Props) {
   const [loading, setLoading] = useState(false);
+  const { showAlert } = useAlertContext();
 
   const send = async () => {
     setLoading(true);
@@ -52,7 +54,8 @@ export default function CreateLetterStep5({
       nextStep(); // 성공 → Step6
     } catch (e) {
       console.error("편지 전송 실패:", e);
-      alert("편지 전송에 실패했습니다.");
+      // alert("편지 전송에 실패했습니다.");
+      showAlert("편지 전송에 실패했습니다", "오류");
     } finally {
       setLoading(false);
     }

--- a/src/app/[year]/(create)/create-moa/step3.tsx
+++ b/src/app/[year]/(create)/create-moa/step3.tsx
@@ -12,6 +12,7 @@ import type { NextStepProps, ServerType } from "@/types/createMoa";
 import SelectModal from "../(components)/SelectModal";
 import Modal from "../../(components)/common/Modal";
 import { useCreateMoa } from "@/contexts/CreateMoaContext";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 export default function CreateMoaStep3({ nextStep }: NextStepProps) {
   const today = dayjs().format("YYYY-MM-DD");
@@ -26,6 +27,7 @@ export default function CreateMoaStep3({ nextStep }: NextStepProps) {
   const [memberColor, setMemberColor] = useState(false);
 
   const { update } = useCreateMoa();
+  const { showAlert } = useAlertContext();
 
   // ───────────── ① 친구 목록 로드 ─────────────
   useEffect(() => {
@@ -65,6 +67,14 @@ export default function CreateMoaStep3({ nextStep }: NextStepProps) {
 
   // ───────────── ③ 다음 단계 (payload 생성) ─────────────
   const handleNext = () => {
+    if (!title) {
+      showAlert("이름을 설정해주세요", "경고");
+      return
+    }
+    else if (startDay === endDay) {
+      showAlert("디데이를 설정해주세요", "경고");
+      return
+    }
     // KST(로컬) 날짜 문자열 → UTC 00:00 ISO
     const isoDueDate = dayjs.utc(endDay).startOf("day").toISOString();
 
@@ -158,7 +168,7 @@ export default function CreateMoaStep3({ nextStep }: NextStepProps) {
                 placeholder="함께 할 친구를 설정해 주세요"
                 className={`${styles.group_member_input} ${
                   memberColor ? styles.color : ""
-                }`}
+                  }`}
                 onClick={() => setOpenSelect(true)}
                 value={memberNames.join(", ")}
                 readOnly

--- a/src/contexts/CreateMoaContext.tsx
+++ b/src/contexts/CreateMoaContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState } from "react";
 import type { CreateMoaBoxInput } from "@/types/moaBoxRequest";
+import { useAlertContext } from "@/contexts/AlertContext";
 
 type Ctx = {
   values: Partial<CreateMoaBoxInput>;
@@ -35,6 +36,8 @@ export default function CreateMoaProvider({
   const update = (p: Partial<CreateMoaBoxInput>) =>
     setValues(v => ({ ...v, ...p }));
 
+  const { showAlert } = useAlertContext();
+
   const submit = async () => {
     const res = await fetch("/api/moa-box", {
       method: "POST",
@@ -44,7 +47,8 @@ export default function CreateMoaProvider({
     });
     if (!res.ok) {
       console.error("모아 생성 검증 에러:", await res.json());
-      alert("모아 생성 실패. 콘솔 확인하세요.");
+      //alert("모아 생성 실패. 콘솔 확인하세요.");
+      showAlert("모아 박스 생성에 실패했습니다", "오류");
       return;
     }
     onSuccess();


### PR DESCRIPTION
## 📌제목 : 제목추가

### ➡️PR 방향

- [ ] 초기(첫 푸시) → 첫 푸시 내용 설명 요망
- [x] 수정 → 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 버그 → 버그 스크린 샷 첨부 요망
- [ ] 요청 → 요청 부분 설명 요망

### 📝내용

-편지 전송 실패 알럿 컴포넌트를 추가했습니다
-모아 박스 생성 실패 알럿 컴포넌트를 추가했습니다
-모바일뷰일때 홈화면에 진입 시 로그인 여부에 따라 로그인 페이지(비로그인), 모아 선택 페이지(로그인)로 이동하도록 수정했습니다
-랜딩페이지 '만들기' 버튼에 페이지 이동 기능을 추가했습니다 : 로그인 여부에 따라 마이 모아 생성화면(로그인), 로그인페이지(비로그인)
-create moa - step 3 에서 제목, 디데이 설정 누락시 경고 알럿 추가 및 다음페이지로 이동할 수 없도록 수정했습니다
-create letter 에서 step6가 추가됨에 따라 navbar 의 점을 6개로 수정했습니다

---

#### ⛓️연결된 이슈 :

closes
